### PR TITLE
Remote SpiceDB Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ proxy.key
 *__failpoint_*.go
 *.go__failpoint*
 *.sqlite
+magefiles/mage_output_file.go

--- a/deploy/proxy.yaml
+++ b/deploy/proxy.yaml
@@ -25,6 +25,8 @@ spec:
       containers:
         - args:
           - --secure-port=8443
+          - --spicedb-endpoint
+          - embedded://
           - --backend-kubeconfig
           - /opt/proxy/kubeconfig
           - --cert-dir

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -105,6 +105,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	opts := proxy.NewOptions()
 	opts.BackendConfig = backendCfg
 	opts.SecureServing.BindPort = port
+	opts.SpiceDBEndpoint = proxy.EmbeddedSpiceDBEndpoint
 	opts.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
 	opts.Authentication.BuiltInOptions.ClientCert.ClientCA = clientCA.Path()
 	Expect(opts.Complete(ctx)).To(Succeed())

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -14,7 +14,7 @@ import (
 
 // GetAllTuples collects all tuples matching the filter from SpiceDB
 func GetAllTuples(ctx context.Context, filter *v1.RelationshipFilter) []*v1.ReadRelationshipsResponse {
-	client, err := proxySrv.SpiceDBClient.ReadRelationships(ctx, &v1.ReadRelationshipsRequest{
+	client, err := proxySrv.PermissionClient().ReadRelationships(ctx, &v1.ReadRelationshipsRequest{
 		Consistency:        &v1.Consistency{Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true}},
 		RelationshipFilter: filter,
 	})

--- a/pkg/proxy/durable_activities.go
+++ b/pkg/proxy/durable_activities.go
@@ -15,12 +15,12 @@ func (s *Server) WriteToSpiceDB(ctx task.ActivityContext) (any, error) {
 		return nil, err
 	}
 	failpoints.FailPoint("panicWriteSpiceDB")
-	out, err := s.SpiceDBClient.WriteRelationships(ctx.Context(), &req)
+	out, err := s.PermissionClient().WriteRelationships(ctx.Context(), &req)
 	failpoints.FailPoint("panicSpiceDBReadResp")
 	return out, err
 }
 
-// WriteToKube
+// WriteToKube peforms a Kube API Server POST, specified in a KubeReqInput propagated via the task.ActivityContext arg
 func (s *Server) WriteToKube(ctx task.ActivityContext) (any, error) {
 	var req KubeReqInput
 	if err := ctx.GetInput(&req); err != nil {

--- a/pkg/proxy/durable_workflows.go
+++ b/pkg/proxy/durable_workflows.go
@@ -22,6 +22,7 @@ const (
 	lockRelationName                 = "workflow"
 	workflowResourceType             = "workflow"
 	MaxKubeAttempts                  = 5
+	DefaultLockMode                  = PessimisticWriteToSpiceDBAndKube
 	OptimisticWriteToSpiceDBAndKube  = "OptimisticWriteToSpiceDBAndKube"
 	PessimisticWriteToSpiceDBAndKube = "PessimisticWriteToSpiceDBAndKube"
 	WriteToSpiceDB                   = "WriteToSpiceDBActivity"

--- a/pkg/proxy/options.go
+++ b/pkg/proxy/options.go
@@ -3,22 +3,34 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/grpcutil"
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/spf13/pflag"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/credentials/insecure"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/component-base/logs"
 	logsv1 "k8s.io/component-base/logs/api/v1"
-
-	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/klog/v2"
 
 	"github.com/authzed/spicedb-kubeapi-proxy/pkg/spicedb"
+)
+
+const (
+	defaultDurableTaskDatabasePath = "/tmp/dtx.sqlite"
+	EmbeddedSpiceDBEndpoint        = "embedded://"
 )
 
 type Options struct {
@@ -35,8 +47,16 @@ type Options struct {
 	ServingInfo           *genericapiserver.SecureServingInfo
 	AdditionalAuthEnabled bool
 
-	SpicedbServer server.RunnableServer
-	SpiceDBClient any
+	WatchClient       v1.WatchServiceClient
+	PermissionsClient v1.PermissionsServiceClient
+	SpiceDBEndpoint   string
+	EmbeddedSpiceDB   server.RunnableServer
+	insecure          bool
+	skipVerifyCA      bool
+	token             string
+
+	DurableTaskDatabasePath string
+	LockMode                string
 }
 
 func NewOptions() *Options {
@@ -55,7 +75,12 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.SecureServing.AddFlags(fs)
 	o.Authentication.AddFlags(fs)
 	logsv1.AddFlags(o.Logs, fs)
+	fs.StringVar(&o.DurableTaskDatabasePath, "durabletask-database-path", defaultDurableTaskDatabasePath, "Path for the file representing the SQLite database used for the durable task engine.")
 	fs.StringVar(&o.BackendKubeconfigPath, "backend-kubeconfig", o.BackendKubeconfigPath, "The path to the kubeconfig to proxy connections to. It should authenticate the user with cluster-admin permission.")
+	fs.StringVar(&o.SpiceDBEndpoint, "spicedb-endpoint", "localhost:50051", "Defines the endpoint endpoint to the SpiceDB authorizing proxy operations. if embedded:// is specified, an in memory ephemeral instance created.")
+	fs.BoolVar(&o.insecure, "spicedb-insecure", false, "If set to true uses the insecure transport configuration for gRPC. Set to false by default.")
+	fs.BoolVar(&o.skipVerifyCA, "spicedb-skip-verify-ca", false, "If set to true backend certificate trust chain is not verified. Set to false by default.")
+	fs.StringVar(&o.token, "spicedb-token", "", "specifies the preshared key to use with the remote SpiceDB")
 }
 
 func (o *Options) Complete(ctx context.Context) error {
@@ -69,14 +94,15 @@ func (o *Options) Complete(ctx context.Context) error {
 		if !filepath.IsAbs(o.BackendKubeconfigPath) {
 			pwd, err := os.Getwd()
 			if err != nil {
-				return err
+				return fmt.Errorf("couldn't load kubeconfig: %w", err)
 			}
 			o.BackendKubeconfigPath = filepath.Join(pwd, o.BackendKubeconfigPath)
 		}
 		o.BackendConfig, err = clientcmd.LoadFromFile(o.BackendKubeconfigPath)
 		if err != nil {
-			return err
+			return fmt.Errorf("couldn't load kubeconfig: %w", err)
 		}
+		klog.FromContext(ctx).WithValues("kubeconfig", o.BackendKubeconfigPath).Error(err, "loaded backend kube config")
 	}
 
 	if !filepath.IsAbs(o.SecureServing.ServerCert.CertDirectory) {
@@ -97,10 +123,58 @@ func (o *Options) Complete(ctx context.Context) error {
 
 	o.AdditionalAuthEnabled = o.Authentication.AdditionalAuthEnabled()
 
-	o.SpicedbServer, err = spicedb.NewServer(ctx)
+	spicedbURl, err := url.Parse(o.SpiceDBEndpoint)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to parse SpiceDB endpoint URL: %w", err)
 	}
+
+	var conn *grpc.ClientConn
+	if spicedbURl.Scheme == "embedded" {
+		klog.FromContext(ctx).WithValues("spicedb-endpoint", o.SpiceDBEndpoint).Info("using embedded SpiceDB")
+		o.EmbeddedSpiceDB, err = spicedb.NewServer(ctx)
+		if err != nil {
+			return fmt.Errorf("unable to stand up embedded SpiceDB: %w", err)
+		}
+
+		conn, err = o.EmbeddedSpiceDB.GRPCDialContext(ctx, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return fmt.Errorf("unable to open gRPC connection with embedded SpiceDB: %w", err)
+		}
+	} else {
+		klog.FromContext(ctx).WithValues("spicedb-endpoint", o.SpiceDBEndpoint).
+			WithValues("spicedb-insecure", o.insecure).
+			WithValues("spicedb-skip-verify-ca", o.skipVerifyCA).
+			Info("using remote SpiceDB")
+		var opts []grpc.DialOption
+		if o.insecure {
+			opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			opts = append(opts, grpcutil.WithInsecureBearerToken(o.token))
+		} else {
+			opts = append(opts, grpcutil.WithBearerToken(o.token))
+			verification := grpcutil.VerifyCA
+			if o.skipVerifyCA {
+				verification = grpcutil.SkipVerifyCA
+			}
+
+			certs, err := grpcutil.WithSystemCerts(verification)
+			if err != nil {
+				return fmt.Errorf("unable to load system certificates: %w", err)
+			}
+
+			opts = append(opts, certs)
+		}
+		opts = append(opts, grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoff.DefaultConfig}))
+
+		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		conn, err = grpc.DialContext(timeoutCtx, o.SpiceDBEndpoint, opts...)
+		if err != nil {
+			return fmt.Errorf("unable to open gRPC connection to remote SpiceDB at %s: %w", o.SpiceDBEndpoint, err)
+		}
+	}
+
+	o.PermissionsClient = v1.NewPermissionsServiceClient(conn)
+	o.WatchClient = v1.NewWatchServiceClient(conn)
 
 	return nil
 }

--- a/pkg/proxy/options_test.go
+++ b/pkg/proxy/options_test.go
@@ -1,0 +1,144 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"testing"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/grpcutil"
+	"github.com/authzed/spicedb/pkg/cmd/datastore"
+	"github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/cmd/util"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/tools/clientcmd"
+	logsv1 "k8s.io/component-base/logs/api/v1"
+)
+
+func TestKubeConfig(t *testing.T) {
+	defer require.NoError(t, logsv1.ResetForTest(utilfeature.DefaultFeatureGate))
+
+	opts := optionsForTesting(t)
+	opts.SpiceDBEndpoint = EmbeddedSpiceDBEndpoint
+	err := opts.Complete(context.Background())
+	require.NoError(t, err)
+
+	require.NoError(t, logsv1.ResetForTest(utilfeature.DefaultFeatureGate))
+	opts = optionsForTesting(t)
+	opts.BackendKubeconfigPath = uuid.NewString()
+	err = opts.Complete(context.Background())
+	require.ErrorContains(t, err, "couldn't load kubeconfig")
+	require.ErrorContains(t, err, opts.BackendKubeconfigPath)
+}
+
+func TestEmbeddedSpiceDB(t *testing.T) {
+	opts := optionsForTesting(t)
+	opts.SpiceDBEndpoint = EmbeddedSpiceDBEndpoint
+	err := opts.Complete(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, opts.EmbeddedSpiceDB)
+	require.NotNil(t, opts.PermissionsClient)
+	require.NotNil(t, opts.WatchClient)
+}
+
+func TestRemoteSpiceDB(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, addr := newServer(t, ctx)
+	go func() {
+		if err := srv.Run(ctx); err != nil {
+			require.NoError(t, err)
+		}
+	}()
+
+	opts := optionsForTesting(t)
+	opts.SpiceDBEndpoint = addr
+	opts.insecure = true
+	opts.token = "foobar"
+	err := opts.Complete(context.Background())
+
+	require.NoError(t, err)
+	require.Nil(t, opts.EmbeddedSpiceDB)
+	require.NotNil(t, opts.PermissionsClient)
+	require.NotNil(t, opts.WatchClient)
+
+	_, err = opts.PermissionsClient.CheckPermission(ctx, &v1.CheckPermissionRequest{})
+	grpcutil.RequireStatus(t, codes.InvalidArgument, err)
+}
+
+func optionsForTesting(t *testing.T) *Options {
+	t.Helper()
+
+	require.NoError(t, logsv1.ResetForTest(utilfeature.DefaultFeatureGate))
+	opts := NewOptions()
+	opts.SecureServing.BindPort = getFreePort(t, "127.0.0.1")
+	opts.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
+	opts.BackendKubeconfigPath = testKubeConfig(t)
+	require.Empty(t, opts.Validate())
+	return opts
+}
+
+func getFreePort(t *testing.T, listenAddr string) int {
+	t.Helper()
+
+	dummyListener, err := net.Listen("tcp", net.JoinHostPort(listenAddr, "0"))
+	require.NoError(t, err)
+
+	defer require.NoError(t, dummyListener.Close())
+	port := dummyListener.Addr().(*net.TCPAddr).Port
+	return port
+}
+
+func newServer(t *testing.T, ctx context.Context) (server.RunnableServer, string) {
+	t.Helper()
+
+	ds, err := datastore.NewDatastore(ctx,
+		datastore.DefaultDatastoreConfig().ToOption(),
+		datastore.WithRequestHedgingEnabled(false),
+	)
+	require.NoError(t, err)
+
+	port := getFreePort(t, "localhost")
+	address := fmt.Sprintf("localhost:%d", port)
+
+	configOpts := []server.ConfigOption{
+		server.WithGRPCServer(util.GRPCServerConfig{
+			Network: "tcp",
+			Address: address,
+			Enabled: true,
+		}),
+		server.WithPresharedSecureKey("foobar"),
+		server.WithHTTPGateway(util.HTTPServerConfig{HTTPEnabled: false}),
+		server.WithMetricsAPI(util.HTTPServerConfig{HTTPEnabled: false}),
+		// disable caching since it's all in memory
+		server.WithDispatchCacheConfig(server.CacheConfig{Enabled: false, Metrics: false}),
+		server.WithNamespaceCacheConfig(server.CacheConfig{Enabled: false, Metrics: false}),
+		server.WithClusterDispatchCacheConfig(server.CacheConfig{Enabled: false, Metrics: false}),
+		server.WithDatastore(ds),
+	}
+
+	srv, err := server.NewConfigWithOptionsAndDefaults(configOpts...).Complete(ctx)
+	require.NoError(t, err)
+
+	return srv, address
+}
+
+func testKubeConfig(t *testing.T) string {
+	t.Helper()
+
+	c, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	require.NoError(t, err)
+	f, err := os.CreateTemp("", "spicedb-kubeapi-proxy")
+	require.NoError(t, err)
+
+	err = clientcmd.WriteToFile(*c, f.Name())
+	require.NoError(t, err)
+
+	return f.Name()
+}


### PR DESCRIPTION
Closes https://github.com/authzed/spicedb-kubeapi-proxy/issues/8
Based on top of https://github.com/authzed/spicedb-kubeapi-proxy/pull/16

The proxy now takes new arguments to configure a remote SpiceDB:

- `spicedb-endpoint`: URL to the remote SpiceDB
- `spicedb-insecure`: allows connecting to SpiceDB in plain text
- `spicedb-skip-verify-ca`: lets the proxy connect to a remote service without
  verifying the certificate trust chain
- `spicedb-token`: the preshared key of the remote server

if spicedb-endpoint is set to `embedded://`, the original
behavior of spinning up an embedded SpiceDB will take place, which
is useful for testing purposes.

An additional flag to support setting a path for the durable task database is
also added: `durabletask-database-path`. It will default to `/tmp/dtx.sqlite`.

### Note

I implemented it so `Complete(context.Context)` wouldn't fail if it was unable to reach to the server. I could have used `WithBlock` and make it fail with a timeout, so that it ends up restarted after it fails kube's health check. I considered that having rakis call the proxy and get a "no healthy backend" wasn't much better than getting an error because the gRPC connection is broken.