### PR TITLE
changes deployment manifest to use statefulset

### DIFF
--- a/deploy/proxy.yaml
+++ b/deploy/proxy.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   labels:
     app: spicedb-kubeapi-proxy
@@ -7,15 +7,11 @@ metadata:
   name: spicedb-kubeapi-proxy
   namespace: kube-system
 spec:
-  replicas: 1
+  serviceName: spicedb-kubeapi-proxy
+  replicas: 2
   selector:
     matchLabels:
       app: spicedb-kubeapi-proxy
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -81,11 +77,19 @@ spec:
         - name: client-ca
           secret:
             secretName: rebac-proxy-request-client-ca
+  volumeClaimTemplates:
+    - metadata:
+        name: workflow-database
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: rebac-proxy
+  name: spicedb-kubeapi-proxy
   namespace: kube-system
 spec:
   type: NodePort


### PR DESCRIPTION
Closes https://github.com/authzed/spicedb-kubeapi-proxy/issues/18
Closes https://github.com/authzed/spicedb-kubeapi-proxy/issues/17

Partially supports https://github.com/authzed/spicedb-kubeapi-proxy/issues/7

With the usage of go-workflows, which we have currently configured with SQLite, we will need some durable persistence for the database WAL.

This PR changes the manifest to use a StatefulSet with 2 replicas for now to demonstrate that state distributed across replicas should be fine for this use case. It also adds a volumeClaimTemplate for the database storage.

# What's the deal with durability and HA

This project is currently configured to persist workflow state to a local SQLite. It turns out having multiple replicas with their own local SQLite databases _should be fine_ because the workflows are engineered to be idempotent and SpiceDB and Kube API server act as the source of truth.

If 2 replicas ended up receiving the exact same request (e.g. a client-side retry), two different `go-workflow` instances with their own SQLite will be executing a workflow. If activities from one instance interleave with those from another instance, the individual activities will be coordinated with the state of the backing SpiceDB/Kube API server.

So for all intent and purposes, durability and high-availability for the MVP will be addressed by:
- using persistent volumes for SQLite WAL
- having multiple replicas with their own independent SQLite WALs, which should be fine