### PR TITLE
support using ambient cluster as upstream

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -9,7 +9,7 @@ configMapGenerator:
 images:
 - name: authzed/spicedb-kubeapi-proxy:dev
   newName: kind.local/spicedb-kubeapi-proxy
-  newTag: 7b6c2489bde6add5e851d3cf2dffd7b85f40539cde75d9bcf86507793f7a785e
+  newTag: cd53bb7c5e6dc804e0580243b17a301226dec1fc40bfc4dd1a9defa13ee6e82c
 kind: Kustomization
 resources:
 - proxy.yaml

--- a/pkg/proxy/options_test.go
+++ b/pkg/proxy/options_test.go
@@ -38,6 +38,20 @@ func TestKubeConfig(t *testing.T) {
 	require.ErrorContains(t, err, opts.BackendKubeconfigPath)
 }
 
+func TestInClusterConfig(t *testing.T) {
+	defer require.NoError(t, logsv1.ResetForTest(utilfeature.DefaultFeatureGate))
+
+	opts := optionsForTesting(t)
+	opts.SpiceDBEndpoint = EmbeddedSpiceDBEndpoint
+	opts.UseInClusterConfig = true
+	require.Empty(t, opts.Validate())
+	err := opts.Complete(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, opts.RestConfigFunc, "missing kube client REST config")
+	_, _, err = opts.RestConfigFunc()
+	require.ErrorContains(t, err, "unable to load in-cluster configuration")
+}
+
 func TestEmbeddedSpiceDB(t *testing.T) {
 	opts := optionsForTesting(t)
 	opts.SpiceDBEndpoint = EmbeddedSpiceDBEndpoint


### PR DESCRIPTION
adds the `--use-in-cluster-config` to support
running the proxy in a kube cluster that
will be used as the target upstream.