### PR TITLE
Handle no matching rules

### DIFF
--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -525,6 +526,15 @@ var _ = Describe("Proxy", func() {
 				lockMode = proxyrule.PessimisticLockMode
 			})
 			AssertDualWriteBehavior()
+		})
+
+		When("no rules match the request", func() {
+			It("returns unauthenticated error", func(ctx context.Context) {
+				*proxySrv.Matcher = rules.MatcherFunc(func(match *request.RequestInfo) []*rules.RunnableRule {
+					return nil
+				})
+				Expect(GetNamespace(ctx, paulClient, paulNamespace)).NotTo(Succeed())
+			})
 		})
 	})
 })

--- a/pkg/authz/authz.go
+++ b/pkg/authz/authz.go
@@ -2,8 +2,10 @@ package authz
 
 import (
 	"context"
-	"k8s.io/klog/v2"
+	"fmt"
 	"net/http"
+
+	"k8s.io/klog/v2"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/cschleiden/go-workflows/client"
@@ -39,6 +41,8 @@ func WithAuthorization(handler, failed http.Handler, permissionsClient v1.Permis
 				"APIGroup", input.Request.APIGroup,
 				"APIVersion", input.Request.APIVersion,
 				"Resource", input.Request.Resource)
+			handleError(w, failed, req, fmt.Errorf("request did not match any authorization rule"))
+			return
 		} else {
 			klog.V(3).InfoSDepth(1,
 				"request matched authorization rule/s",

--- a/pkg/proxy/authn_test.go
+++ b/pkg/proxy/authn_test.go
@@ -136,7 +136,9 @@ func runProxyRequest(t testing.TB, ctx context.Context, headers map[string][]str
 	opts.SecureServing.BindPort = port
 	opts.Authentication.BuiltInOptions.RequestHeader = headerOpts
 	opts.Matcher = rules.MatcherFunc(func(match *request.RequestInfo) []*rules.RunnableRule {
-		return nil
+		return []*rules.RunnableRule{{
+			Checks: []*rules.RelExpr{},
+		}}
 	})
 
 	var info user.Info


### PR DESCRIPTION
### Description

Ensures that requests to the proxy are rejected if there are no matching proxy rules.

Resolves #62 