### PR TITLE
Full consistency

### DIFF
--- a/pkg/authz/check.go
+++ b/pkg/authz/check.go
@@ -29,7 +29,7 @@ func runAllMatchingChecks(ctx context.Context, matchingRules []*rules.RunnableRu
 				}
 				req := &v1.CheckPermissionRequest{
 					Consistency: &v1.Consistency{
-						Requirement: &v1.Consistency_MinimizeLatency{MinimizeLatency: true},
+						Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true},
 					},
 					Resource: &v1.ObjectReference{
 						ObjectType: rel.ResourceType,

--- a/pkg/authz/filter.go
+++ b/pkg/authz/filter.go
@@ -80,7 +80,7 @@ func filterList(ctx context.Context, client v1.PermissionsServiceClient, filter 
 
 		req := &v1.LookupResourcesRequest{
 			Consistency: &v1.Consistency{
-				Requirement: &v1.Consistency_MinimizeLatency{MinimizeLatency: true},
+				Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true},
 			},
 			ResourceObjectType: filter.Rel.ResourceType,
 			Permission:         filter.Rel.ResourceRelation,


### PR DESCRIPTION
### Description

Fixes "read-after-write" race condition caused by Rakis creating a Kubernetes `Secret` and then immediately updating it. In the future, the consistency should be configurable and allow the use of ZedTokens with `AtLeastAsFresh` consistency.

This is a stopgap solution to #43