### PR TITLE
set fsGroup in deploy manifests

### DIFF
--- a/deploy/proxy.yaml
+++ b/deploy/proxy.yaml
@@ -112,6 +112,7 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
         runAsNonRoot: true
+        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
   volumeClaimTemplates:


### PR DESCRIPTION
this sets the mounted workflow directory to match the group the pod is running as