### PR TITLE
fix dockerfile

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -10,8 +10,6 @@ on: # yamllint disable-line rule:truthy
   merge_group:
     types:
       - "checks_requested"
-env:
-  GO_VERSION: "~1.21.1"
 jobs:
   paths-filter:
     runs-on: "ubuntu-latest"
@@ -42,8 +40,6 @@ jobs:
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/setup-go@main"
-        with:
-          go-version: "${{ env.GO_VERSION }}"
       - uses: "authzed/actions/go-build@main"
 
   unit:
@@ -55,8 +51,6 @@ jobs:
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/setup-go@main"
-        with:
-          go-version: "${{ env.GO_VERSION }}"
       - name: "Unit tests"
         uses: "magefile/mage-action@v2"
         with:
@@ -72,8 +66,6 @@ jobs:
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/setup-go@main"
-        with:
-          go-version: "${{ env.GO_VERSION }}"
       - name: "e2e tests"
         uses: "magefile/mage-action@v2"
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22.1-alpine3.18 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.4-alpine3.22 AS builder
 ARG TARGETOS TARGETARCH
 
 WORKDIR /go/src/spicedb-kubeapi-proxy


### PR DESCRIPTION
Fixes

```
[20:25:10] ~/Documents/GitHub/spicedb-kubeapi-proxy (main) $ docker build . -t proxy       
[+] Building 3.9s (10/11)                                                   docker:desktop-linux
 => [internal] load build definition from Dockerfile                                        0.0s
 => => transferring dockerfile: 540B                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.22.1-alpine3.18                 0.4s
 => [internal] load metadata for cgr.dev/chainguard/static:latest                           0.6s
 => [internal] load .dockerignore                                                           0.0s
 => => transferring context: 2B                                                             0.0s
 => [builder 1/4] FROM docker.io/library/golang:1.22.1-alpine3.18@sha256:ede158fb846dd8689  2.8s
 => => resolve docker.io/library/golang:1.22.1-alpine3.18@sha256:ede158fb846dd8689c757a779  0.0s
 => => sha256:7a26229665d7c5f9cb9a4f00a8b65397bfca3ac2e32db5984bf0cb23954ffc47 174B / 174B  0.2s
 => => sha256:45f98fcb73bca57a7708e937f885c06af78a776543e6429cde3763173b 66.25MB / 66.25MB  1.7s
 => => sha256:a69c4102457739613c6fcb205a5a8e7dbc8383d57dade0a4502b1bca 286.31kB / 286.31kB  0.4s
 => => sha256:c6b39de5b33961661dc939b997cc1d30cda01e38005a6c6625fd9c7e748b 3.33MB / 3.33MB  0.5s
 => => extracting sha256:c6b39de5b33961661dc939b997cc1d30cda01e38005a6c6625fd9c7e748bab44   0.0s
 => => extracting sha256:a69c4102457739613c6fcb205a5a8e7dbc8383d57dade0a4502b1bca7b100a4d   0.0s
 => => extracting sha256:45f98fcb73bca57a7708e937f885c06af78a776543e6429cde3763173b097858   0.9s
 => => extracting sha256:7a26229665d7c5f9cb9a4f00a8b65397bfca3ac2e32db5984bf0cb23954ffc47   0.0s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1   0.0s
 => [stage-1 1/2] FROM cgr.dev/chainguard/static:latest@sha256:3c0cfe403ce6f1ff7761aab4824  0.0s
 => => resolve cgr.dev/chainguard/static:latest@sha256:3c0cfe403ce6f1ff7761aab482448e5d497  0.0s
 => [internal] load build context                                                           0.0s
 => => transferring context: 35.95kB                                                        0.0s
 => [builder 2/4] WORKDIR /go/src/spicedb-kubeapi-proxy                                     0.2s
 => [builder 3/4] COPY . /go/src/spicedb-kubeapi-proxy                                      0.1s
 => ERROR [builder 4/4] RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=c  0.1s
------                                                                                           
 > [builder 4/4] RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./cmd/spicedb-kubeapi-proxy:
0.126 go: go.mod requires go >= 1.24.4 (running go 1.22.1; GOTOOLCHAIN=local)
------
Dockerfile:8
--------------------
   6 |     COPY . /go/src/spicedb-kubeapi-proxy
   7 |     
   8 | >>> RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build ./cmd/spicedb-kubeapi-proxy
   9 |     
  10 |     FROM cgr.dev/chainguard/static
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build ./cmd/spicedb-kubeapi-proxy" did not complete successfully: exit code: 1

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/zmkmtosiztft4iubqp2gjf365
[20:25:18] ~/Documents/GitHub/spicedb-kubeapi-proxy (main) $ 
```