### PR TITLE
rules: support generating a set of tuples from one input document

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ There are three basic types of rule:
   SpiceDB based on the request that the proxy is authorizing. For example,
   if `alice` creates a new pod `c` in namespace `foo`, a rule can determine
   that a relationship should be written to SpiceDB that grants ownership,
-  i.e. `pod:foo/a#view@user:alice`.
+  i.e. `pod:foo/a#view@user:alice`. Rules support both single relationship
+  templates and **tupleSet** expressions that can generate multiple relationships
+  dynamically based on resource content (e.g., one relationship per container
+  in a Deployment).
 
 Rules often work in tendem; for example, a `Check` rule might authorize a request
 to list pods in a namespace, and a `Filter` rule might further restrict the

--- a/pkg/authz/check.go
+++ b/pkg/authz/check.go
@@ -6,12 +6,102 @@ import (
 	"fmt"
 
 	"golang.org/x/sync/errgroup"
-	"k8s.io/klog/v2"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
 	"github.com/authzed/spicedb-kubeapi-proxy/pkg/rules"
 )
+
+// checkRelationships performs authorization checks for a slice of relationships
+// Uses single CheckPermission for one relationship, bulk CheckBulkPermissions for multiple
+func checkRelationships(ctx context.Context, client v1.PermissionsServiceClient, resolvedRels []*rules.ResolvedRel, checkType string) error {
+	if len(resolvedRels) == 0 {
+		return nil
+	}
+
+	if len(resolvedRels) == 1 {
+		// Single check - use regular CheckPermission
+		rel := resolvedRels[0]
+		req := &v1.CheckPermissionRequest{
+			Consistency: &v1.Consistency{
+				Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true},
+			},
+			Resource: &v1.ObjectReference{
+				ObjectType: rel.ResourceType,
+				ObjectId:   rel.ResourceID,
+			},
+			Permission: rel.ResourceRelation,
+			Subject: &v1.SubjectReference{
+				Object: &v1.ObjectReference{
+					ObjectType: rel.SubjectType,
+					ObjectId:   rel.SubjectID,
+				},
+				OptionalRelation: rel.SubjectRelation,
+			},
+		}
+		resp, err := client.CheckPermission(ctx, req)
+		if err != nil {
+			return err
+		}
+		if resp.Permissionship != v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION {
+			return fmt.Errorf("%s failed for %s:%s#%s@%s:%s",
+				checkType, rel.ResourceType, rel.ResourceID, rel.ResourceRelation,
+				rel.SubjectType, rel.SubjectID)
+		}
+		return nil
+	}
+
+	// Multiple checks - use bulk check
+	items := make([]*v1.CheckBulkPermissionsRequestItem, len(resolvedRels))
+	for i, rel := range resolvedRels {
+		items[i] = &v1.CheckBulkPermissionsRequestItem{
+			Resource: &v1.ObjectReference{
+				ObjectType: rel.ResourceType,
+				ObjectId:   rel.ResourceID,
+			},
+			Permission: rel.ResourceRelation,
+			Subject: &v1.SubjectReference{
+				Object: &v1.ObjectReference{
+					ObjectType: rel.SubjectType,
+					ObjectId:   rel.SubjectID,
+				},
+				OptionalRelation: rel.SubjectRelation,
+			},
+		}
+	}
+
+	bulkReq := &v1.CheckBulkPermissionsRequest{
+		Consistency: &v1.Consistency{
+			Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true},
+		},
+		Items: items,
+	}
+
+	bulkResp, err := client.CheckBulkPermissions(ctx, bulkReq)
+	if err != nil {
+		return err
+	}
+
+	// All checks must pass
+	for i, pair := range bulkResp.Pairs {
+		if pair.GetError() != nil {
+			rel := resolvedRels[i]
+			return fmt.Errorf("bulk %s error for %s:%s#%s@%s:%s: %v",
+				checkType, rel.ResourceType, rel.ResourceID, rel.ResourceRelation,
+				rel.SubjectType, rel.SubjectID, pair.GetError())
+		}
+
+		responseItem := pair.GetItem()
+		if responseItem == nil || responseItem.Permissionship != v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION {
+			rel := resolvedRels[i]
+			return fmt.Errorf("bulk %s failed for %s:%s#%s@%s:%s",
+				checkType, rel.ResourceType, rel.ResourceID, rel.ResourceRelation,
+				rel.SubjectType, rel.SubjectID)
+		}
+	}
+
+	return nil
+}
 
 var ErrUnauthorized = errors.New("unauthorized operation")
 
@@ -23,36 +113,12 @@ func runAllMatchingChecks(ctx context.Context, matchingRules []*rules.RunnableRu
 		for _, c := range r.Checks {
 			c := c
 			checkGroup.Go(func() error {
-				rel, err := rules.ResolveRel(c, input)
+				resolvedRels, err := c.GenerateRelationships(input)
 				if err != nil {
 					return err
 				}
-				req := &v1.CheckPermissionRequest{
-					Consistency: &v1.Consistency{
-						Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true},
-					},
-					Resource: &v1.ObjectReference{
-						ObjectType: rel.ResourceType,
-						ObjectId:   rel.ResourceID,
-					},
-					Permission: rel.ResourceRelation,
-					Subject: &v1.SubjectReference{
-						Object: &v1.ObjectReference{
-							ObjectType: rel.SubjectType,
-							ObjectId:   rel.SubjectID,
-						},
-						OptionalRelation: rel.SubjectRelation,
-					},
-				}
-				resp, err := client.CheckPermission(ctx, req)
-				klog.V(3).InfoSDepth(1, "CheckPermission", "request", req, "response", resp, "error", err)
-				if err != nil {
-					return fmt.Errorf("failed runAllMatchingChecks: %w", err)
-				}
-				if resp.Permissionship != v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION {
-					return ErrUnauthorized
-				}
-				return nil
+
+				return checkRelationships(ctx, client, resolvedRels, "check")
 			})
 		}
 	}
@@ -67,36 +133,12 @@ func runAllMatchingPostChecks(ctx context.Context, matchingRules []*rules.Runnab
 		for _, c := range r.PostChecks {
 			c := c
 			postCheckGroup.Go(func() error {
-				rel, err := rules.ResolveRel(c, input)
+				resolvedRels, err := c.GenerateRelationships(input)
 				if err != nil {
 					return err
 				}
-				req := &v1.CheckPermissionRequest{
-					Consistency: &v1.Consistency{
-						Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true},
-					},
-					Resource: &v1.ObjectReference{
-						ObjectType: rel.ResourceType,
-						ObjectId:   rel.ResourceID,
-					},
-					Permission: rel.ResourceRelation,
-					Subject: &v1.SubjectReference{
-						Object: &v1.ObjectReference{
-							ObjectType: rel.SubjectType,
-							ObjectId:   rel.SubjectID,
-						},
-						OptionalRelation: rel.SubjectRelation,
-					},
-				}
-				resp, err := client.CheckPermission(ctx, req)
-				klog.V(3).InfoSDepth(1, "PostCheckPermission", "request", req, "response", resp, "error", err)
-				if err != nil {
-					return fmt.Errorf("failed runAllMatchingPostChecks: %w", err)
-				}
-				if resp.Permissionship != v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION {
-					return ErrUnauthorized
-				}
-				return nil
+
+				return checkRelationships(ctx, client, resolvedRels, "postcheck")
 			})
 		}
 	}

--- a/pkg/proxy/authn_test.go
+++ b/pkg/proxy/authn_test.go
@@ -171,7 +171,7 @@ func runProxyRequest(t testing.TB, ctx context.Context, headers map[string][]str
 	opts.Authentication.BuiltInOptions.RequestHeader = headerOpts
 	opts.Matcher = rules.MatcherFunc(func(match *request.RequestInfo) []*rules.RunnableRule {
 		return []*rules.RunnableRule{{
-			Checks: []*rules.RelExpr{},
+			Checks: []rules.RelationshipExpr{},
 		}}
 	})
 

--- a/pkg/rules/env.go
+++ b/pkg/rules/env.go
@@ -7,14 +7,14 @@ import (
 	"github.com/warpstreamlabs/bento/public/bloblang"
 )
 
-// Custom Bloblang environment with splitName and splitNamespace functions
+// Custom Bloblang environment
 var customBloblangEnv *bloblang.Environment
 
 func init() {
-	// Create custom Bloblang environment with splitName and splitNamespace functions
+	// Create custom Bloblang environment
 	customBloblangEnv = bloblang.NewEnvironment()
 
-	// Register split_name function
+	// Register split_name function for backward compatibility
 	err := customBloblangEnv.RegisterFunction("split_name", func(args ...any) (bloblang.Function, error) {
 		return func() (any, error) {
 			if len(args) != 1 {
@@ -35,7 +35,7 @@ func init() {
 		panic(fmt.Sprintf("failed to register split_name function: %v", err))
 	}
 
-	// Register split_namespace function
+	// Register split_namespace function for backward compatibility
 	err = customBloblangEnv.RegisterFunction("split_namespace", func(args ...any) (bloblang.Function, error) {
 		return func() (any, error) {
 			if len(args) != 1 {

--- a/pkg/rules/tupleset_test.go
+++ b/pkg/rules/tupleset_test.go
@@ -1,0 +1,439 @@
+package rules
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/authzed/spicedb-kubeapi-proxy/pkg/config/proxyrule"
+)
+
+func TestTupleSetExpr_GenerateRelationships(t *testing.T) {
+	tests := []struct {
+		name       string
+		tupleSet   string
+		input      *ResolveInput
+		want       []*ResolvedRel
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:     "deployment containers",
+			tupleSet: `this.namespacedName.(nsName -> this.object.spec.template.spec.containers.map_each("deployment:" + nsName + "#has-container@container:" + this.name))`,
+			input: createDeploymentInput("test-deployment", "default", []containerSpec{
+				{name: "server"},
+				{name: "config-reloader"},
+				{name: "proxy-sidecar"},
+			}),
+			want: []*ResolvedRel{
+				{
+					ResourceType:     "deployment",
+					ResourceID:       "default/test-deployment",
+					ResourceRelation: "has-container",
+					SubjectType:      "container",
+					SubjectID:        "server",
+				},
+				{
+					ResourceType:     "deployment",
+					ResourceID:       "default/test-deployment",
+					ResourceRelation: "has-container",
+					SubjectType:      "container",
+					SubjectID:        "config-reloader",
+				},
+				{
+					ResourceType:     "deployment",
+					ResourceID:       "default/test-deployment",
+					ResourceRelation: "has-container",
+					SubjectType:      "container",
+					SubjectID:        "proxy-sidecar",
+				},
+			},
+		},
+		{
+			name:     "empty container list",
+			tupleSet: `this.namespacedName.(nsName -> this.object.spec.template.spec.containers.map_each("deployment:" + nsName + "#has-container@container:" + this.name))`,
+			input:    createDeploymentInput("test-deployment", "default", []containerSpec{}),
+			want:     []*ResolvedRel{},
+		},
+		{
+			name:     "with filtering",
+			tupleSet: `this.namespacedName.(nsName -> this.object.spec.template.spec.containers.filter(this.name != "proxy-sidecar").map_each("deployment:" + nsName + "#has-container@container:" + this.name))`,
+			input: createDeploymentInput("test-deployment", "default", []containerSpec{
+				{name: "server"},
+				{name: "proxy-sidecar"},
+			}),
+			want: []*ResolvedRel{
+				{
+					ResourceType:     "deployment",
+					ResourceID:       "default/test-deployment",
+					ResourceRelation: "has-container",
+					SubjectType:      "container",
+					SubjectID:        "server",
+				},
+			},
+		},
+		{
+			name:     "service ports",
+			tupleSet: `this.namespacedName.(nsName -> this.object.spec.ports.map_each("service:" + nsName + "#exposes-port@port:" + if this.name != null { this.name } else { this.port.string() }))`,
+			input:    createServiceInput("test-service", "default"),
+			want: []*ResolvedRel{
+				{
+					ResourceType:     "service",
+					ResourceID:       "default/test-service",
+					ResourceRelation: "exposes-port",
+					SubjectType:      "port",
+					SubjectID:        "http",
+				},
+				{
+					ResourceType:     "service",
+					ResourceID:       "default/test-service",
+					ResourceRelation: "exposes-port",
+					SubjectType:      "port",
+					SubjectID:        "8080",
+				},
+			},
+		},
+		{
+			name:       "non-array result",
+			tupleSet:   `"single-string"`,
+			input:      createSimpleInput("test", "default"),
+			wantErr:    true,
+			wantErrMsg: "tuple set expression must return an array",
+		},
+		{
+			name:       "invalid relationship string",
+			tupleSet:   `["invalid-relationship-format"]`,
+			input:      createSimpleInput("test", "default"),
+			wantErr:    true,
+			wantErrMsg: "error parsing relationship string",
+		},
+		{
+			name:     "handle null/missing fields safely",
+			tupleSet: `this.namespacedName.(nsName -> (this.object.spec.template.spec.initContainers | []).map_each("deployment:" + nsName + "#has-init-container@container:" + this.name))`,
+			input:    createDeploymentInput("test-deployment", "default", []containerSpec{{name: "server"}}), // no initContainers
+			want:     []*ResolvedRel{},
+		},
+		{
+			name: "let syntax with explicit root assignment",
+			tupleSet: `let nsName = this.namespacedName
+				root = this.object.spec.template.spec.containers.map_each("deployment:" + $nsName + "#has-container@container:" + this.name)`,
+			input: createDeploymentInput("test-deployment", "default", []containerSpec{
+				{name: "server"},
+				{name: "sidecar"},
+			}),
+			want: []*ResolvedRel{
+				{
+					ResourceType:     "deployment",
+					ResourceID:       "default/test-deployment",
+					ResourceRelation: "has-container",
+					SubjectType:      "container",
+					SubjectID:        "server",
+				},
+				{
+					ResourceType:     "deployment",
+					ResourceID:       "default/test-deployment",
+					ResourceRelation: "has-container",
+					SubjectType:      "container",
+					SubjectID:        "sidecar",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor, err := CompileTupleSetExpression(tt.tupleSet)
+			require.NoError(t, err)
+
+			tupleSetExpr := &TupleSetExpr{
+				Expression: executor,
+			}
+
+			got, err := tupleSetExpr.GenerateRelationships(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrMsg != "" {
+					require.Contains(t, err.Error(), tt.wantErrMsg)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.want == nil && got == nil {
+				return // both nil is fine
+			}
+			if len(tt.want) == 0 && len(got) == 0 {
+				return // both empty is fine
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCompileStringOrObjTemplatesWithTupleSet(t *testing.T) {
+	templates := []proxyrule.StringOrTemplate{
+		{
+			Template: "deployment:{{namespacedName}}#creator@user:{{user.name}}",
+		},
+		{
+			TupleSet: `this.namespacedName.(nsName -> this.object.spec.template.spec.containers.map_each("deployment:" + nsName + "#has-container@container:" + this.name))`,
+		},
+	}
+
+	exprs, err := compileStringOrObjTemplates(templates)
+	require.NoError(t, err)
+	require.Len(t, exprs, 2)
+
+	// First should be a RelExpr
+	_, ok := exprs[0].(*RelExpr)
+	require.True(t, ok, "First expression should be a RelExpr")
+
+	// Second should be a TupleSetExpr
+	_, ok = exprs[1].(*TupleSetExpr)
+	require.True(t, ok, "Second expression should be a TupleSetExpr")
+}
+
+func TestTupleSetValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		template proxyrule.StringOrTemplate
+		wantErr  bool
+	}{
+		{
+			name: "valid tupleSet only",
+			template: proxyrule.StringOrTemplate{
+				TupleSet: `["test"]`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid template only",
+			template: proxyrule.StringOrTemplate{
+				Template: "test:{{name}}#rel@user:{{user.name}}",
+			},
+			wantErr: false,
+		},
+		{
+			name: "tupleSet with template - should fail validation at config level",
+			template: proxyrule.StringOrTemplate{
+				Template: "test:{{name}}#rel@user:{{user.name}}",
+				TupleSet: `["test"]`,
+			},
+			// This should be caught by config validation, not compilation
+			wantErr: false, // compilation doesn't validate mutual exclusion
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := compileStringOrObjTemplates([]proxyrule.StringOrTemplate{tt.template})
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Test helpers
+
+type containerSpec struct {
+	name  string
+	image string
+}
+
+func createDeploymentInput(name, namespace string, containers []containerSpec) *ResolveInput {
+	containerObjs := make([]map[string]any, len(containers))
+	for i, c := range containers {
+		containerObjs[i] = map[string]any{
+			"name": c.name,
+		}
+		if c.image != "" {
+			containerObjs[i]["image"] = c.image
+		}
+	}
+
+	deploymentSpec := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": containerObjs,
+				},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(deploymentSpec)
+
+	return &ResolveInput{
+		Name:           name,
+		Namespace:      namespace,
+		NamespacedName: namespace + "/" + name,
+		Request: &request.RequestInfo{
+			Verb:     "create",
+			Resource: "deployments",
+		},
+		User: &user.DefaultInfo{
+			Name: "testuser",
+		},
+		Object: &metav1.PartialObjectMetadata{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		},
+		Body: body,
+	}
+}
+
+func createServiceInput(name, namespace string) *ResolveInput {
+	serviceSpec := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]any{
+			"ports": []map[string]any{
+				{
+					"name": "http",
+					"port": 80,
+				},
+				{
+					"port": 8080,
+				},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(serviceSpec)
+
+	return &ResolveInput{
+		Name:           name,
+		Namespace:      namespace,
+		NamespacedName: namespace + "/" + name,
+		Request: &request.RequestInfo{
+			Verb:     "create",
+			Resource: "services",
+		},
+		User: &user.DefaultInfo{
+			Name: "testuser",
+		},
+		Object: &metav1.PartialObjectMetadata{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		},
+		Body: body,
+	}
+}
+
+func createSimpleInput(name, namespace string) *ResolveInput {
+	return &ResolveInput{
+		Name:           name,
+		Namespace:      namespace,
+		NamespacedName: namespace + "/" + name,
+		Request: &request.RequestInfo{
+			Verb:     "create",
+			Resource: "pods",
+		},
+		User: &user.DefaultInfo{
+			Name: "testuser",
+		},
+	}
+}
+
+func TestTupleSetInChecksAndPreconditions(t *testing.T) {
+	tests := []struct {
+		name     string
+		tupleSet string
+		input    *ResolveInput
+		want     []*ResolvedRel
+		wantErr  bool
+	}{
+		{
+			name:     "check all containers in deployment",
+			tupleSet: `this.user.name.(userName -> this.object.spec.template.spec.containers.map_each("container:" + this.name + "#deploy@user:" + userName))`,
+			input: createDeploymentInput("web-app", "production", []containerSpec{
+				{name: "server"},
+				{name: "sidecar"},
+			}),
+			want: []*ResolvedRel{
+				{
+					ResourceType:     "container",
+					ResourceID:       "server",
+					ResourceRelation: "deploy",
+					SubjectType:      "user",
+					SubjectID:        "testuser",
+				},
+				{
+					ResourceType:     "container",
+					ResourceID:       "sidecar",
+					ResourceRelation: "deploy",
+					SubjectType:      "user",
+					SubjectID:        "testuser",
+				},
+			},
+		},
+		{
+			name:     "precondition for multiple secrets",
+			tupleSet: `["secret:" + this.namespace + "/secret1#exists@system:cluster", "secret:" + this.namespace + "/secret2#exists@system:cluster"]`,
+			input:    createSimpleInput("test-pod", "default"),
+			want: []*ResolvedRel{
+				{
+					ResourceType:     "secret",
+					ResourceID:       "default/secret1",
+					ResourceRelation: "exists",
+					SubjectType:      "system",
+					SubjectID:        "cluster",
+				},
+				{
+					ResourceType:     "secret",
+					ResourceID:       "default/secret2",
+					ResourceRelation: "exists",
+					SubjectType:      "system",
+					SubjectID:        "cluster",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor, err := CompileTupleSetExpression(tt.tupleSet)
+			require.NoError(t, err)
+
+			tupleSetExpr := &TupleSetExpr{
+				Expression: executor,
+			}
+
+			got, err := tupleSetExpr.GenerateRelationships(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.want == nil && got == nil {
+				return // both nil is fine
+			}
+			if len(tt.want) == 0 && len(got) == 0 {
+				return // both empty is fine
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This allows you to write new rules that generate sets of tuples:

For example:
```
let pod_prefix = "pod:" + this.namespacedName
root = this.object.spec.containers.map_each($pod_prefix + "#has-container@container:" + this.name)
```

might generate tuples `pod:default/foo#has-container@container:service`, `pod:default/foo#has-container@container:sidecar`, `pod:default/foo#has-container@container:config-reloader`, etc.

You can use full bloblang in this expression, the expectation is that it returns an `[]string` in the tuple string format. We may want to offer a structured form in the future.

They can be used in write rules or as checks, which now also run as bulk check against spicedb.