### PR TITLE
tests: fix tests timing out due to stuck goroutines

### DIFF
--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -36,6 +36,7 @@ func (t Test) E2e() error {
 		"-covermode=atomic",
 		"--keep-separate-coverprofiles",
 		"--output-dir=../",
+		"--timeout=5m",
 		"-r",
 		"-vv",
 		"--fail-fast",


### PR DESCRIPTION
I'm investigating why sometimes the tests flake out and then get stuck:

```yaml
E0724 12:21:24.181173   64941 authz.go:86] "input failed authorization checks" err="bulk check failed for testresource:paul-slkmg/paul-cr-cxcs7#edit@user:chani" name="paul-cr-cxcs7" namespace="paul-slkmg" namespacedName="paul-slkmg/paul-cr-cxcs7" object="nil" body="" request.verb="delete" request.resource="testresources" request.labelSelector="" request.fieldSelector="" request.path="/apis/example.com/v1/namespaces/paul-slkmg/testresources/paul-cr-cxcs7" user.name="chani" user.groups=["authzed","system:authenticated"] user.extra={"[authentication.kubernetes.io/credential-id](http://authentication.kubernetes.io/credential-id)":["X509SHA256=f1d2beb6ecec89127b356efbb87d6539f71b19c1c2314b8069dedcc707cc9860"]} User-Agent=["e2e.test/v0.0.0 (darwin/arm64) kubernetes/$Format"] Content-Length=["43"] Accept-Encoding=["gzip"] Accept=["application/json"] Content-Type=["application/json"]
```

This PR doesn't fix that issue but at least the tests don't get stuck when this happens.

Now I consistently see this:

```go
------------------------------
• [FAILED] [10.033 seconds]
Proxy when there are two users when optimistic locking is used [It] supports rules for every verb on custom resources
/Users/miparnisari/Documents/GitHub/spicedb-kubeapi-proxy/e2e/proxy_test.go:469

  [FAILED] Expected
      <[]string | len:0, cap:1>: []
  to contain element matching
      <string>: paul-cr-lq64l
  In [It] at: /Users/miparnisari/Documents/GitHub/spicedb-kubeapi-proxy/e2e/proxy_test.go:475 @ 07/24/25 15:10:26.446
```