### PR TITLE
fixes race in filtering

### DIFF
--- a/pkg/authz/filter.go
+++ b/pkg/authz/filter.go
@@ -98,8 +98,8 @@ type wrapper struct {
 }
 
 func filterList(ctx context.Context, client v1.PermissionsServiceClient, filter *rules.ResolvedPreFilter, input *rules.ResolveInput, authzData *AuthzData) {
+	authzData.Lock()
 	go func() {
-		authzData.Lock()
 		defer authzData.Unlock()
 		defer close(authzData.allowedNNC)
 		defer close(authzData.removedNNC)


### PR DESCRIPTION
the call in AuthzData.FilterList to RLock the mutex may happen before the goroutine is started

as an interim solution until https://github.com/authzed/spicedb-kubeapi-proxy/pull/149 implements Watch support