### PR TITLE
fix: request logger

### DIFF
--- a/pkg/authz/requestlogger.go
+++ b/pkg/authz/requestlogger.go
@@ -1,0 +1,30 @@
+package authz
+
+import (
+	"net/http"
+	"strings"
+)
+
+func requestLogger(r *http.Request) string {
+	var sb strings.Builder
+
+	sb.WriteString(r.Method)
+	sb.WriteString(" ")
+	sb.WriteString(r.URL.String())
+
+	var bodyBytes []byte
+	if r.Body != nil {
+		defer func() {
+			_ = r.Body.Close()
+		}()
+		bodyBytes = make([]byte, r.ContentLength)
+		_, err := r.Body.Read(bodyBytes)
+		if err != nil {
+			sb.WriteString("Body: <unknown>")
+		} else {
+			sb.WriteString(" Body: " + string(bodyBytes))
+		}
+	}
+
+	return sb.String()
+}

--- a/pkg/authz/requestlogger_test.go
+++ b/pkg/authz/requestlogger_test.go
@@ -1,0 +1,64 @@
+package authz
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestLogger(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		url      string
+		body     string
+		expected string
+	}{
+		{
+			name:     "GET request without query or body",
+			method:   "GET",
+			url:      "https://kubernetes.default.svc/api/v1/pods",
+			body:     "",
+			expected: "GET https://kubernetes.default.svc/api/v1/pods",
+		},
+		{
+			name:     "GET request with query parameters",
+			method:   "GET",
+			url:      "https://kubernetes.default.svc/api/v1/pods?labelSelector=app%3Dmyapp&limit=10",
+			body:     "",
+			expected: "GET https://kubernetes.default.svc/api/v1/pods?labelSelector=app%3Dmyapp&limit=10",
+		},
+		{
+			name:     "POST request with body",
+			method:   "POST",
+			url:      "https://kubernetes.default.svc/api/v1/namespaces/default/pods",
+			body:     `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test"}}`,
+			expected: `POST https://kubernetes.default.svc/api/v1/namespaces/default/pods Body: {"apiVersion":"v1","kind":"Pod","metadata":{"name":"test"}}`,
+		},
+		{
+			name:     "PUT request with query and body",
+			method:   "PUT",
+			url:      "https://kubernetes.default.svc/api/v1/namespaces/default/pods/test?dryRun=All",
+			body:     `{"metadata":{"labels":{"env":"prod"}}}`,
+			expected: `PUT https://kubernetes.default.svc/api/v1/namespaces/default/pods/test?dryRun=All Body: {"metadata":{"labels":{"env":"prod"}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var bodyReader io.Reader
+			if tt.body != "" {
+				bodyReader = strings.NewReader(tt.body)
+			}
+
+			req, err := http.NewRequest(tt.method, tt.url, bodyReader)
+			require.NoError(t, err)
+
+			result := requestLogger(req)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/authz/responsefilterer.go
+++ b/pkg/authz/responsefilterer.go
@@ -126,7 +126,7 @@ func (rf *StandardResponseFilterer) RunPreFilters(req *http.Request) error {
 
 	prefilterRule, err := singlePreFilterRule(rf.filteredRules)
 	if err != nil {
-		klog.FromContext(req.Context()).V(2).Error(err, "error getting single pre-filter rule", "request", req)
+		klog.FromContext(req.Context()).V(2).Error(err, "error getting single pre-filter rule", "request", requestLogger(req))
 		return fmt.Errorf("error getting single pre-filter rule: %w", err)
 	}
 
@@ -163,17 +163,17 @@ func (rf *StandardResponseFilterer) RunPreFilters(req *http.Request) error {
 
 	// Run LookupResources for the prefilter rule and write the results to the channel.
 	go func() {
-		klog.FromContext(req.Context()).V(3).Info("running pre-filter", "request", req, "filter", filter)
+		klog.FromContext(req.Context()).V(3).Info("running pre-filter", "request", requestLogger(req), "filter", filter)
 
 		result, err := runLookupResources(req.Context(), rf.client, filter, rf.input)
 		if err != nil {
 			if status.Code(err) == codes.Canceled {
-				klog.FromContext(req.Context()).V(3).Info("pre-filter canceled", "request", req)
+				klog.FromContext(req.Context()).V(3).Info("pre-filter canceled", "request", requestLogger(req))
 				rf.preFilterCompleted <- prefilterResult{err: err}
 				return
 			}
 
-			klog.FromContext(req.Context()).Error(err, "error running pre-filter", "request", req)
+			klog.FromContext(req.Context()).Error(err, "error running pre-filter", "request", requestLogger(req))
 			rf.preFilterCompleted <- prefilterResult{
 				err: err,
 			}


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

Prevents this kind of logs:

```
2025-09-15 11:04:11 AM 0 | {"level":"error","error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: tls: failed to verify certificate: x509: certificate signed by unknown authority\"","request":"marshaling error: json: unsupported type: func() (io.ReadCloser, error)","time":"2025-09-15T18:04:11Z","message":"error running pre-filter"}
```

## Testing

Unit tests

## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->