### PR TITLE
build: check for docker and kustomizer where applicable

### DIFF
--- a/magefiles/dev.go
+++ b/magefiles/dev.go
@@ -57,6 +57,12 @@ func (d Dev) Run() error {
 
 // Up brings up a dev cluster with the proxy installed.
 func (d Dev) Up(ctx context.Context) error {
+	if err := checkDocker(); err != nil {
+		return err
+	}
+	if err := checkKustomizer(); err != nil {
+		return err
+	}
 	var proxyHostPort int32
 	if _, err := os.Stat(kubeconfigPath); err != nil {
 		proxyHostPort, err = GetFreePort("localhost")
@@ -220,6 +226,9 @@ func getBytesFromSecretField(ctx context.Context, clientset *kubernetes.Clientse
 
 // Clean deletes the dev stack cluster.
 func (d Dev) Clean() error {
+	if err := checkDocker(); err != nil {
+		return err
+	}
 	provider := kind.NewProvider(
 		kind.ProviderWithLogger(cmd.NewLogger()),
 	)


### PR DESCRIPTION
Address this bit from https://github.com/authzed/spicedb-kubeapi-proxy/issues/177

> Make sure kustomizer is installed. I didn’t have this installed initially, which triggered the error:
Error: failed to run "kustomizer apply inventory spicedb-kubeapi-proxy -k ./deploy --prune --wait --timeout 5m: exec: "kustomizer": executable file not found in $PATH"
> (This requirement isn’t mentioned in the README.)