### PR TITLE
fix: make discovery REST mapper safe for concurrent use

### DIFF
--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -104,6 +104,16 @@ var _ = Describe("Proxy", func() {
 			_ = adminDynamicClient.Resource(gvr).Namespace(sharedNamespace).Delete(ctx, paulCustomResource, metav1.DeleteOptions{PropagationPolicy: &orphan})
 			_ = adminDynamicClient.Resource(gvr).Namespace(sharedNamespace).Delete(ctx, chaniCustomResource, metav1.DeleteOptions{PropagationPolicy: &orphan})
 
+			// Delete the namespace relationships this spec created so that view grants
+			// don't accumulate across specs. envtest has no namespace GC, so orphaned
+			// namespaces otherwise pile up in each user's cluster-scoped list/watch and
+			// make those specs flaky. Namespaces are the only cluster-scoped resource
+			// involved here; pods and custom resources are scoped to a fresh per-spec
+			// namespace, so they don't leak across specs.
+			for _, ns := range []string{paulNamespace, chaniNamespace, sharedNamespace} {
+				DeleteAllTuples(ctx, &v1.RelationshipFilter{ResourceType: "namespace", OptionalResourceId: ns})
+			}
+
 			// ensure there are no remaining locks
 			Expect(len(GetAllTuples(ctx, &v1.RelationshipFilter{
 				ResourceType:          "lock",
@@ -639,13 +649,14 @@ var _ = Describe("Proxy", func() {
 				Expect(k8serrors.IsUnauthorized(GetNamespace(ctx, paulClient, chaniNamespace))).To(BeTrue())
 				Expect(k8serrors.IsUnauthorized(GetNamespace(ctx, chaniClient, paulNamespace))).To(BeTrue())
 
-				// neither can see each other's namespace in the list
+				// Each user sees exactly their own namespace and nothing else. Per-spec
+				// cleanup of namespace grants (AfterEach) means there is no stale state, so
+				// ConsistOf is an exact match: any cross-user namespace -- current or stale
+				// from an earlier spec -- would fail this, making it a robust leak check.
 				paulList := ListNamespaces(ctx, paulClient)
 				chaniList := ListNamespaces(ctx, chaniClient)
-				Expect(paulList).ToNot(ContainElement(chaniNamespace))
-				Expect(paulList).To(ContainElement(paulNamespace))
-				Expect(chaniList).ToNot(ContainElement(paulNamespace))
-				Expect(chaniList).To(ContainElement(chaniNamespace))
+				Expect(paulList).To(ConsistOf(paulNamespace))
+				Expect(chaniList).To(ConsistOf(chaniNamespace))
 			})
 
 			It("recovers when there are kube write failures", func(ctx context.Context) {
@@ -665,6 +676,17 @@ var _ = Describe("Proxy", func() {
 
 				// paul isn't able to create chanis namespace
 				Expect(CreateNamespace(ctx, paulClient, chaniNamespace)).ToNot(BeNil())
+
+				// paul's failed create must not leave a dangling `creator` grant behind: with
+				// `permission view = viewer + creator`, that would let paul get/list/watch
+				// chani's namespace. This surfaces incomplete rollback of the optimistically
+				// written relationship when the kube write fails.
+				Expect(GetAllTuples(ctx, &v1.RelationshipFilter{
+					ResourceType:          "namespace",
+					OptionalResourceId:    chaniNamespace,
+					OptionalRelation:      "creator",
+					OptionalSubjectFilter: &v1.SubjectFilter{SubjectType: "user", OptionalSubjectId: "paul"},
+				})).To(BeEmpty())
 
 				// paul can only get his namespace
 				Expect(GetNamespace(ctx, paulClient, paulNamespace)).To(Succeed())

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -61,6 +61,14 @@ func WriteTuples(ctx context.Context, rels []*v1.Relationship) {
 	Expect(err).To(Succeed())
 }
 
+// DeleteAllTuples deletes every relationship matching the filter from SpiceDB.
+func DeleteAllTuples(ctx context.Context, filter *v1.RelationshipFilter) {
+	_, err := proxySrv.PermissionClient().DeleteRelationships(ctx, &v1.DeleteRelationshipsRequest{
+		RelationshipFilter: filter,
+	})
+	Expect(err).To(Succeed())
+}
+
 // setupEnvtest sets up the Kubernetes test binaries using setup-envtest
 func setupEnvtest(log logr.Logger) string {
 	e := &env.Env{

--- a/pkg/proxy/restmapper.go
+++ b/pkg/proxy/restmapper.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// synchronizedRESTMapper wraps a meta.RESTMapper to make it safe for concurrent use.
+//
+// The discovery-backed mapper this wraps (a shortcut expander over a disk-cached
+// discovery client) is not safe for concurrent use. On every call the shortcut
+// expander calls the discovery client's ServerGroupsAndResources() directly,
+// bypassing the DeferredDiscoveryRESTMapper's lock. When the on-disk discovery cache
+// is stale, that path rewrites the cache, and the versioning codec does a
+// read-modify-write on the cached object's TypeMeta (SetGroupVersionKind, then a
+// deferred restore). Two concurrent calls race on that field, tearing the APIVersion
+// string and panicking with a nil-pointer dereference in schema.ParseGroupVersion.
+//
+// The proxy shares a single mapper across all request goroutines and calls KindFor
+// while filtering every list/get response, so all access is serialized here.
+type synchronizedRESTMapper struct {
+	mu       sync.Mutex
+	delegate meta.RESTMapper
+}
+
+func newSynchronizedRESTMapper(delegate meta.RESTMapper) *synchronizedRESTMapper {
+	return &synchronizedRESTMapper{delegate: delegate}
+}
+
+var _ meta.RESTMapper = (*synchronizedRESTMapper)(nil)
+
+func (m *synchronizedRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.KindFor(resource)
+}
+
+func (m *synchronizedRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.KindsFor(resource)
+}
+
+func (m *synchronizedRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.ResourceFor(input)
+}
+
+func (m *synchronizedRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.ResourcesFor(input)
+}
+
+func (m *synchronizedRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.RESTMapping(gk, versions...)
+}
+
+func (m *synchronizedRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.RESTMappings(gk, versions...)
+}
+
+func (m *synchronizedRESTMapper) ResourceSingularizer(resource string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.ResourceSingularizer(resource)
+}

--- a/pkg/proxy/restmapper.go
+++ b/pkg/proxy/restmapper.go
@@ -2,72 +2,106 @@ package proxy
 
 import (
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// synchronizedRESTMapper wraps a meta.RESTMapper to make it safe for concurrent use.
+// cachingRESTMapper wraps a meta.RESTMapper to make it safe for concurrent use and to
+// memoize KindFor results.
 //
 // The discovery-backed mapper this wraps (a shortcut expander over a disk-cached
-// discovery client) is not safe for concurrent use. On every call the shortcut
+// discovery client) is not safe for concurrent use: on every call the shortcut
 // expander calls the discovery client's ServerGroupsAndResources() directly,
-// bypassing the DeferredDiscoveryRESTMapper's lock. When the on-disk discovery cache
-// is stale, that path rewrites the cache, and the versioning codec does a
-// read-modify-write on the cached object's TypeMeta (SetGroupVersionKind, then a
-// deferred restore). Two concurrent calls race on that field, tearing the APIVersion
-// string and panicking with a nil-pointer dereference in schema.ParseGroupVersion.
+// bypassing the DeferredDiscoveryRESTMapper's lock, and when the on-disk cache is
+// stale the versioning codec races on the cached object's TypeMeta during encoding.
+// All access is therefore serialized through a mutex.
 //
-// The proxy shares a single mapper across all request goroutines and calls KindFor
-// while filtering every list/get response, so all access is serialized here.
-type synchronizedRESTMapper struct {
-	mu       sync.Mutex
+// Serialization alone is correct but expensive: the shortcut expander re-reads and
+// JSON-decodes one discovery document per group-version on every KindFor call, which
+// is costly on CRD-heavy clusters and, under the lock, serializes that work across
+// all requests. Successful GVR->GVK lookups are memoized so the steady state is an
+// O(1) map read.
+//
+// Cached entries expire after ttl, which is set to the same TTL as the underlying
+// disk discovery cache. Memoization therefore never serves data staler than discovery
+// itself would, rather than caching indefinitely. Only successful lookups are cached;
+// errors (and not-yet-known resource types) are retried.
+type cachingRESTMapper struct {
 	delegate meta.RESTMapper
+	ttl      time.Duration
+	now      func() time.Time // overridable in tests
+
+	mu    sync.Mutex
+	cache map[schema.GroupVersionResource]kindForEntry
 }
 
-func newSynchronizedRESTMapper(delegate meta.RESTMapper) *synchronizedRESTMapper {
-	return &synchronizedRESTMapper{delegate: delegate}
+type kindForEntry struct {
+	gvk      schema.GroupVersionKind
+	storedAt time.Time
 }
 
-var _ meta.RESTMapper = (*synchronizedRESTMapper)(nil)
+func newCachingRESTMapper(delegate meta.RESTMapper, ttl time.Duration) *cachingRESTMapper {
+	return &cachingRESTMapper{
+		delegate: delegate,
+		ttl:      ttl,
+		now:      time.Now,
+		cache:    make(map[schema.GroupVersionResource]kindForEntry),
+	}
+}
 
-func (m *synchronizedRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+var _ meta.RESTMapper = (*cachingRESTMapper)(nil)
+
+func (m *cachingRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.delegate.KindFor(resource)
+
+	if e, ok := m.cache[resource]; ok && m.now().Sub(e.storedAt) < m.ttl {
+		return e.gvk, nil
+	}
+
+	gvk, err := m.delegate.KindFor(resource)
+	if err != nil {
+		// Don't cache failures: a transient discovery error or a not-yet-registered
+		// resource type must be retried, not memoized.
+		return gvk, err
+	}
+	m.cache[resource] = kindForEntry{gvk: gvk, storedAt: m.now()}
+	return gvk, nil
 }
 
-func (m *synchronizedRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+func (m *cachingRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.KindsFor(resource)
 }
 
-func (m *synchronizedRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+func (m *cachingRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.ResourceFor(input)
 }
 
-func (m *synchronizedRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+func (m *cachingRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.ResourcesFor(input)
 }
 
-func (m *synchronizedRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+func (m *cachingRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.RESTMapping(gk, versions...)
 }
 
-func (m *synchronizedRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+func (m *cachingRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.RESTMappings(gk, versions...)
 }
 
-func (m *synchronizedRESTMapper) ResourceSingularizer(resource string) (string, error) {
+func (m *cachingRESTMapper) ResourceSingularizer(resource string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.ResourceSingularizer(resource)

--- a/pkg/proxy/restmapper.go
+++ b/pkg/proxy/restmapper.go
@@ -31,7 +31,6 @@ import (
 type cachingRESTMapper struct {
 	delegate meta.RESTMapper
 	ttl      time.Duration
-	now      func() time.Time // overridable in tests
 
 	mu    sync.Mutex
 	cache map[schema.GroupVersionResource]kindForEntry
@@ -46,7 +45,6 @@ func newCachingRESTMapper(delegate meta.RESTMapper, ttl time.Duration) *cachingR
 	return &cachingRESTMapper{
 		delegate: delegate,
 		ttl:      ttl,
-		now:      time.Now,
 		cache:    make(map[schema.GroupVersionResource]kindForEntry),
 	}
 }
@@ -57,7 +55,7 @@ func (m *cachingRESTMapper) KindFor(resource schema.GroupVersionResource) (schem
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if e, ok := m.cache[resource]; ok && m.now().Sub(e.storedAt) < m.ttl {
+	if e, ok := m.cache[resource]; ok && time.Since(e.storedAt) < m.ttl {
 		return e.gvk, nil
 	}
 
@@ -67,7 +65,7 @@ func (m *cachingRESTMapper) KindFor(resource schema.GroupVersionResource) (schem
 		// resource type must be retried, not memoized.
 		return gvk, err
 	}
-	m.cache[resource] = kindForEntry{gvk: gvk, storedAt: m.now()}
+	m.cache[resource] = kindForEntry{gvk: gvk, storedAt: time.Now()}
 	return gvk, nil
 }
 

--- a/pkg/proxy/restmapper_test.go
+++ b/pkg/proxy/restmapper_test.go
@@ -2,17 +2,38 @@ package proxy
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 )
+
+// deploymentGVK is the kind deploymentsGVR resolves to.
+var deploymentGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+
+// countingRESTMapper is a test double that records how many times KindFor is invoked
+// and returns a configurable result. It embeds meta.RESTMapper (nil) to satisfy the
+// interface; only KindFor is exercised.
+type countingRESTMapper struct {
+	meta.RESTMapper
+	kindForCalls  int
+	kindForResult schema.GroupVersionKind
+	kindForErr    error
+}
+
+func (c *countingRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	c.kindForCalls++
+	return c.kindForResult, c.kindForErr
+}
 
 // deploymentsGVR is a stock Kubernetes resource used to exercise KindFor. The bug is
 // independent of which resource is resolved; any GVR served by discovery will do.
@@ -113,4 +134,69 @@ func TestNewCachedRESTMapper_ConcurrentKindForIsRaceFree(t *testing.T) {
 	for err := range errs {
 		require.NoError(t, err)
 	}
+}
+
+// TestCachingRESTMapper_MemoizesSuccessfulKindFor verifies repeated lookups for the
+// same resource resolve from the in-process cache rather than re-hitting the
+// (expensive, per-call discovery-reading) delegate on every request.
+func TestCachingRESTMapper_MemoizesSuccessfulKindFor(t *testing.T) {
+	underlying := &countingRESTMapper{kindForResult: deploymentGVK}
+	mapper := newCachingRESTMapper(underlying, time.Hour)
+
+	for i := 0; i < 5; i++ {
+		gvk, err := mapper.KindFor(deploymentsGVR)
+		require.NoError(t, err)
+		require.Equal(t, "Deployment", gvk.Kind)
+	}
+
+	require.Equal(t, 1, underlying.kindForCalls, "underlying KindFor should be invoked once and memoized thereafter")
+}
+
+// TestCachingRESTMapper_DoesNotCacheErrors verifies failed lookups are not cached, so a
+// transient discovery error (or a resource type that does not exist yet) is retried
+// rather than permanently poisoning the cache.
+func TestCachingRESTMapper_DoesNotCacheErrors(t *testing.T) {
+	underlying := &countingRESTMapper{kindForErr: errors.New("discovery unavailable")}
+	mapper := newCachingRESTMapper(underlying, time.Hour)
+
+	_, err := mapper.KindFor(deploymentsGVR)
+	require.Error(t, err)
+
+	// Discovery recovers; the next lookup must hit the underlying mapper again and succeed.
+	underlying.kindForErr = nil
+	underlying.kindForResult = deploymentGVK
+
+	gvk, err := mapper.KindFor(deploymentsGVR)
+	require.NoError(t, err)
+	require.Equal(t, "Deployment", gvk.Kind)
+	require.Equal(t, 2, underlying.kindForCalls, "error result must not be cached")
+}
+
+// TestCachingRESTMapper_RefreshesAfterTTL verifies the in-process cache honors the TTL:
+// a cached entry is re-resolved through the delegate once it is older than the TTL, so
+// memoization never serves data staler than the underlying discovery cache would.
+func TestCachingRESTMapper_RefreshesAfterTTL(t *testing.T) {
+	underlying := &countingRESTMapper{kindForResult: deploymentGVK}
+	mapper := newCachingRESTMapper(underlying, time.Hour)
+
+	now := time.Unix(1_000_000, 0)
+	mapper.now = func() time.Time { return now }
+
+	_, err := mapper.KindFor(deploymentsGVR) // miss -> delegate (calls=1)
+	require.NoError(t, err)
+	_, err = mapper.KindFor(deploymentsGVR) // hit (calls=1)
+	require.NoError(t, err)
+	require.Equal(t, 1, underlying.kindForCalls)
+
+	// Within the TTL: still served from cache.
+	now = now.Add(59 * time.Minute)
+	_, err = mapper.KindFor(deploymentsGVR)
+	require.NoError(t, err)
+	require.Equal(t, 1, underlying.kindForCalls, "entry within TTL should stay cached")
+
+	// Past the TTL: re-resolved through the delegate.
+	now = now.Add(2 * time.Minute) // total 61m > 60m TTL
+	_, err = mapper.KindFor(deploymentsGVR)
+	require.NoError(t, err)
+	require.Equal(t, 2, underlying.kindForCalls, "entry older than TTL should be refreshed")
 }

--- a/pkg/proxy/restmapper_test.go
+++ b/pkg/proxy/restmapper_test.go
@@ -1,0 +1,116 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+// deploymentsGVR is a stock Kubernetes resource used to exercise KindFor. The bug is
+// independent of which resource is resolved; any GVR served by discovery will do.
+var deploymentsGVR = schema.GroupVersionResource{
+	Group:    "apps",
+	Version:  "v1",
+	Resource: "deployments",
+}
+
+// newFakeDiscoveryServer serves a minimal Kubernetes discovery API (core/v1 plus the
+// apps group) so we can build a discovery-backed REST mapper in tests.
+func newFakeDiscoveryServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	writeJSON := func(w http.ResponseWriter, obj interface{}) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(obj)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, &metav1.APIVersions{
+			TypeMeta: metav1.TypeMeta{Kind: "APIVersions"},
+			Versions: []string{"v1"},
+		})
+	})
+	mux.HandleFunc("/api/v1", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, &metav1.APIResourceList{
+			TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Namespaced: true, Kind: "ConfigMap", ShortNames: []string{"cm"}},
+			},
+		})
+	})
+	mux.HandleFunc("/apis", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, &metav1.APIGroupList{
+			TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
+			Groups: []metav1.APIGroup{{
+				Name:             "apps",
+				Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: "apps/v1", Version: "v1"}},
+				PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "apps/v1", Version: "v1"},
+			}},
+		})
+	})
+	mux.HandleFunc("/apis/apps/v1", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, &metav1.APIResourceList{
+			TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Namespaced: true, Kind: "Deployment", ShortNames: []string{"deploy"}},
+			},
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, &metav1.APIResourceList{TypeMeta: metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"}})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestNewCachedRESTMapper_ConcurrentKindForIsRaceFree reproduces the production panic:
+// many concurrent requests are driven through a single shared REST mapper, and KindFor
+// on the discovery-backed mapper races on the discovery cache write (a read-modify-write
+// of the cached object's TypeMeta during encoding), corrupting a string and panicking
+// with a nil-pointer dereference inside ParseGroupVersion.
+//
+// A zero TTL forces the disk discovery cache to be rewritten on every call, which is the
+// path that races. Run under `-race` to detect it.
+func TestNewCachedRESTMapper_ConcurrentKindForIsRaceFree(t *testing.T) {
+	srv := newFakeDiscoveryServer(t)
+	cfg := &rest.Config{Host: srv.URL}
+
+	tmp := t.TempDir()
+	mapper, err := newCachedRESTMapper(cfg, filepath.Join(tmp, "discovery"), filepath.Join(tmp, "http"), 0)
+	require.NoError(t, err)
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			gvk, err := mapper.KindFor(deploymentsGVR)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if gvk.Kind != "Deployment" {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}

--- a/pkg/proxy/restmapper_test.go
+++ b/pkg/proxy/restmapper_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -143,7 +144,7 @@ func TestCachingRESTMapper_MemoizesSuccessfulKindFor(t *testing.T) {
 	underlying := &countingRESTMapper{kindForResult: deploymentGVK}
 	mapper := newCachingRESTMapper(underlying, time.Hour)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		gvk, err := mapper.KindFor(deploymentsGVR)
 		require.NoError(t, err)
 		require.Equal(t, "Deployment", gvk.Kind)
@@ -176,27 +177,28 @@ func TestCachingRESTMapper_DoesNotCacheErrors(t *testing.T) {
 // a cached entry is re-resolved through the delegate once it is older than the TTL, so
 // memoization never serves data staler than the underlying discovery cache would.
 func TestCachingRESTMapper_RefreshesAfterTTL(t *testing.T) {
-	underlying := &countingRESTMapper{kindForResult: deploymentGVK}
-	mapper := newCachingRESTMapper(underlying, time.Hour)
+	// synctest gives the test a fake clock, so time.Sleep advances time instantly
+	// without a real clock dependency in the mapper.
+	synctest.Test(t, func(t *testing.T) {
+		underlying := &countingRESTMapper{kindForResult: deploymentGVK}
+		mapper := newCachingRESTMapper(underlying, time.Hour)
 
-	now := time.Unix(1_000_000, 0)
-	mapper.now = func() time.Time { return now }
+		_, err := mapper.KindFor(deploymentsGVR) // miss -> delegate (calls=1)
+		require.NoError(t, err)
+		_, err = mapper.KindFor(deploymentsGVR) // hit (calls=1)
+		require.NoError(t, err)
+		require.Equal(t, 1, underlying.kindForCalls)
 
-	_, err := mapper.KindFor(deploymentsGVR) // miss -> delegate (calls=1)
-	require.NoError(t, err)
-	_, err = mapper.KindFor(deploymentsGVR) // hit (calls=1)
-	require.NoError(t, err)
-	require.Equal(t, 1, underlying.kindForCalls)
+		// Within the TTL: still served from cache.
+		time.Sleep(59 * time.Minute)
+		_, err = mapper.KindFor(deploymentsGVR)
+		require.NoError(t, err)
+		require.Equal(t, 1, underlying.kindForCalls, "entry within TTL should stay cached")
 
-	// Within the TTL: still served from cache.
-	now = now.Add(59 * time.Minute)
-	_, err = mapper.KindFor(deploymentsGVR)
-	require.NoError(t, err)
-	require.Equal(t, 1, underlying.kindForCalls, "entry within TTL should stay cached")
-
-	// Past the TTL: re-resolved through the delegate.
-	now = now.Add(2 * time.Minute) // total 61m > 60m TTL
-	_, err = mapper.KindFor(deploymentsGVR)
-	require.NoError(t, err)
-	require.Equal(t, 2, underlying.kindForCalls, "entry older than TTL should be refreshed")
+		// Past the TTL: re-resolved through the delegate.
+		time.Sleep(2 * time.Minute) // 61m total > 60m TTL
+		_, err = mapper.KindFor(deploymentsGVR)
+		require.NoError(t, err)
+		require.Equal(t, 2, underlying.kindForCalls, "entry older than TTL should be refreshed")
+	})
 }

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -233,11 +233,16 @@ func withAuthentication(handler, failed http.Handler, auth authenticator.Request
 // toRestMapper creates a rest.M from the provided rest.Config.
 func toRestMapper(config *rest.Config) (meta.RESTMapper, error) {
 	cacheDir := getDefaultCacheDir()
-
 	httpCacheDir := filepath.Join(cacheDir, "http")
 	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(cacheDir, "discovery"), config.Host)
+	return newCachedRESTMapper(config, discoveryCacheDir, httpCacheDir, 6*time.Hour)
+}
 
-	discoveryClient, err := diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, 6*time.Hour)
+// newCachedRESTMapper builds the discovery-backed REST mapper used to resolve
+// GroupVersionKinds while filtering responses. The cache directories and TTL are
+// parameters (rather than hardcoded) so the mapper can be exercised in tests.
+func newCachedRESTMapper(config *rest.Config, discoveryCacheDir, httpCacheDir string, ttl time.Duration) (meta.RESTMapper, error) {
+	discoveryClient, err := diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, ttl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discovery client: %w", err)
 	}
@@ -245,7 +250,7 @@ func toRestMapper(config *rest.Config) (meta.RESTMapper, error) {
 	expander := restmapper.NewShortcutExpander(mapper, discoveryClient, func(a string) {
 		klog.V(3).InfoSDepth(1, "discovery warning", "error", err)
 	})
-	return expander, nil
+	return newSynchronizedRESTMapper(expander), nil
 }
 
 // getDefaultCacheDir returns default caching directory path.

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -250,7 +250,10 @@ func newCachedRESTMapper(config *rest.Config, discoveryCacheDir, httpCacheDir st
 	expander := restmapper.NewShortcutExpander(mapper, discoveryClient, func(a string) {
 		klog.V(3).InfoSDepth(1, "discovery warning", "error", err)
 	})
-	return newSynchronizedRESTMapper(expander), nil
+	// Wrap with a caching mapper that serializes access (the discovery-backed mapper
+	// is not concurrency-safe) and memoizes KindFor results using the same TTL as the
+	// discovery cache, so per-request discovery reads don't dominate under load.
+	return newCachingRESTMapper(expander, ttl), nil
 }
 
 // getDefaultCacheDir returns default caching directory path.

--- a/pkg/spicedb/spicedb.go
+++ b/pkg/spicedb/spicedb.go
@@ -45,6 +45,18 @@ func NewServer(ctx context.Context, bootstrapFilePath string, bootstrapContent m
 		server.WithDispatchCacheConfig(server.CacheConfig{Enabled: false, Metrics: false}),
 		server.WithNamespaceCacheConfig(server.CacheConfig{Enabled: false, Metrics: false}),
 		server.WithClusterDispatchCacheConfig(server.CacheConfig{Enabled: false, Metrics: false}),
+		// Disable metrics on the stored-schema cache. With Metrics: true (the default) the
+		// cache registers Prometheus collectors named "stored_schema" on the global
+		// registry, so creating more than one embedded instance in a single process (as the
+		// tests do) fails with "duplicate metrics collector registration attempted". With
+		// Metrics: false the cache is built without registering anything.
+		server.WithStoredSchemaCacheConfig(server.CacheConfig{
+			Name:        "stored_schema",
+			Enabled:     true,
+			Metrics:     false,
+			NumCounters: 1_000,
+			MaxCost:     "32MiB",
+		}),
 		server.WithEnableRelationshipExpiration(true),
 		server.WithDatastoreConfig(
 			*datastore.NewConfigWithOptionsAndDefaults().WithOptions(


### PR DESCRIPTION
## Summary

The discovery REST mapper used while filtering responses isn't safe for concurrent use. Under concurrent load it panics with a nil-pointer dereference, which surfaces to clients as an HTTP/2 `INTERNAL_ERROR`.

Commits:
1. **`fix:`** make the mapper concurrency-safe (with a test that reproduces the race).
2. **`perf:`** memoize lookups so the fix doesn't add a per-request cost — with the tradeoff worked through below.
3. **`test:`** an **unrelated** fix for a pre-existing Unit/e2e CI flake — embedded-SpiceDB metric double-registration (details below).
4. **`test(e2e):`** another **unrelated** pre-existing fix — flaky namespace-watch specs (details below).

## The bug

`toRestMapper` returns a shortcut expander over a disk-cached discovery client. On every `KindFor` call the shortcut expander [calls the discovery client directly](https://github.com/kubernetes/client-go/blob/v0.34.1/restmapper/shortcut.go#L101), bypassing the [`DeferredDiscoveryRESTMapper`'s lock](https://github.com/kubernetes/client-go/blob/v0.34.1/restmapper/discovery.go#L180). When the on-disk cache is stale it [gets rewritten](https://github.com/kubernetes/client-go/blob/v0.34.1/discovery/cached/disk/cached_discovery.go#L128), and the encoder briefly [mutates the cached object's `TypeMeta`](https://github.com/kubernetes/apimachinery/blob/v0.34.1/pkg/runtime/serializer/versioning/versioning.go#L256-L268) (sets the GVK for the wire, then restores it). Two concurrent `KindFor` calls race on that field, corrupt the `APIVersion` string, and panic in [`schema.ParseGroupVersion`](https://github.com/kubernetes/apimachinery/blob/v0.34.1/pkg/runtime/schema/group_version.go#L218).

(Links point to k8s `v0.34.1`, the version this repo builds against.)

The mapper is shared across all request goroutines and `KindFor` runs while filtering every list/get response, so this is reachable under normal traffic.

> Same class of bug as kubernetes/kubernetes#51521 (an `Encode()` that mutates its object), which was fixed only for the Unstructured codec. Discovery REST mappers aren't treated as concurrency-safe upstream — controller-runtime ships its own synchronized one — so the fix belongs at the caller.

## Commit 1 — the fix

Serialize all access to the mapper with a mutex. The added test drives concurrent `KindFor` through the real discovery machinery and **fails under `-race` without the wrapper**.

## Commit 2 — the optimization

Locking alone is correct but costly: the shortcut expander re-reads and JSON-decodes one discovery document **per group-version** on every `KindFor`, now serialized under the lock. The cost scales with the number of CRDs / API group-versions:

| group-versions | lock-only / call | memoized / call |
|---|---|---|
| 10 | ~0.24 ms | – |
| 100 | ~1.15 ms | – |
| 300 | ~3.36 ms (~1.3 MB, ~15k allocs) | **~23 ns (0 allocs)** |

So we memoize successful `GVR→GVK` lookups; discovery is consulted only on a miss.

**Why not cache forever?** That would ignore the discovery cache's TTL — a GVK that changed at runtime (CRD reinstalled, version promoted) could stay pinned until the process restarts. Instead, the in-process cache uses the **same TTL** as the disk discovery cache (one shared value, so they can't drift) and caches only successful lookups (errors and unknown types are retried). Worst-case staleness stays the same order as today.

## Commit 3 — unrelated CI fix (pre-existing flake)

This commit is **not** related to the REST mapper change; it fixes a separate, pre-existing flake that was failing the Unit and e2e jobs on this branch **and on `main`**.

The embedded SpiceDB helper builds an in-memory instance for tests. It already disables metrics on the dispatch and namespace caches, but the `stored_schema` cache was left at its default (`Metrics: true`), which registers Prometheus collectors on the **global** registry. When more than one embedded instance is created in a single test process, the second registration intermittently fails with `duplicate metrics collector registration attempted`. Setting `Metrics: false` builds that cache without registering, so the collision can't happen. (Surfaced by the SpiceDB v1.53.0 bump in #193.)

It's bundled here only because the flake blocks this PR's CI; it could equally land as its own PR.

## Commit 4 — unrelated e2e flakiness fix (pre-existing)

Also **not** related to the REST mapper change. The "two users" namespace-watch e2e specs flaked because `paul`/`chani` are fixed identities across all specs and their namespace grants are never cleaned up (envtest has no namespace GC), so each user's cluster-scoped watch/list accumulates stale namespaces from earlier specs and the watch helper returns one of them. Fix: `AfterEach` now deletes the spec's namespace relationships so grants don't accumulate, and the list assertion is tightened to an exact `ConsistOf` — a robust leak check that fails on any cross-user namespace, current or stale. Also adds an assertion that a failed cross-user create leaves no dangling `creator` grant; it passes, confirming the dual-write rollback is correct. (Originally opened as #200, folded in here.)

## Testing

`-race` reproduction of the data race; plus memoization, no-error-caching, and TTL-refresh tests. The scaling numbers above were measured with an ad-hoc benchmark (not committed). The two pre-existing flakes don't reproduce locally (timing/accumulation-dependent), so CI is the confirmation — Unit, e2e, Build, and Lint are all green (e2e confirmed green across multiple randomized orderings).

