### PR TITLE
test(e2e): fix flaky namespace-watch specs (+ rollback guard)

### DIFF
--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -104,6 +104,16 @@ var _ = Describe("Proxy", func() {
 			_ = adminDynamicClient.Resource(gvr).Namespace(sharedNamespace).Delete(ctx, paulCustomResource, metav1.DeleteOptions{PropagationPolicy: &orphan})
 			_ = adminDynamicClient.Resource(gvr).Namespace(sharedNamespace).Delete(ctx, chaniCustomResource, metav1.DeleteOptions{PropagationPolicy: &orphan})
 
+			// Delete the namespace relationships this spec created so that view grants
+			// don't accumulate across specs. envtest has no namespace GC, so orphaned
+			// namespaces otherwise pile up in each user's cluster-scoped list/watch and
+			// make those specs flaky. Namespaces are the only cluster-scoped resource
+			// involved here; pods and custom resources are scoped to a fresh per-spec
+			// namespace, so they don't leak across specs.
+			for _, ns := range []string{paulNamespace, chaniNamespace, sharedNamespace} {
+				DeleteAllTuples(ctx, &v1.RelationshipFilter{ResourceType: "namespace", OptionalResourceId: ns})
+			}
+
 			// ensure there are no remaining locks
 			Expect(len(GetAllTuples(ctx, &v1.RelationshipFilter{
 				ResourceType:          "lock",
@@ -639,13 +649,14 @@ var _ = Describe("Proxy", func() {
 				Expect(k8serrors.IsUnauthorized(GetNamespace(ctx, paulClient, chaniNamespace))).To(BeTrue())
 				Expect(k8serrors.IsUnauthorized(GetNamespace(ctx, chaniClient, paulNamespace))).To(BeTrue())
 
-				// neither can see each other's namespace in the list
+				// Each user sees exactly their own namespace and nothing else. Per-spec
+				// cleanup of namespace grants (AfterEach) means there is no stale state, so
+				// ConsistOf is an exact match: any cross-user namespace -- current or stale
+				// from an earlier spec -- would fail this, making it a robust leak check.
 				paulList := ListNamespaces(ctx, paulClient)
 				chaniList := ListNamespaces(ctx, chaniClient)
-				Expect(paulList).ToNot(ContainElement(chaniNamespace))
-				Expect(paulList).To(ContainElement(paulNamespace))
-				Expect(chaniList).ToNot(ContainElement(paulNamespace))
-				Expect(chaniList).To(ContainElement(chaniNamespace))
+				Expect(paulList).To(ConsistOf(paulNamespace))
+				Expect(chaniList).To(ConsistOf(chaniNamespace))
 			})
 
 			It("recovers when there are kube write failures", func(ctx context.Context) {
@@ -665,6 +676,17 @@ var _ = Describe("Proxy", func() {
 
 				// paul isn't able to create chanis namespace
 				Expect(CreateNamespace(ctx, paulClient, chaniNamespace)).ToNot(BeNil())
+
+				// paul's failed create must not leave a dangling `creator` grant behind: with
+				// `permission view = viewer + creator`, that would let paul get/list/watch
+				// chani's namespace. This surfaces incomplete rollback of the optimistically
+				// written relationship when the kube write fails.
+				Expect(GetAllTuples(ctx, &v1.RelationshipFilter{
+					ResourceType:          "namespace",
+					OptionalResourceId:    chaniNamespace,
+					OptionalRelation:      "creator",
+					OptionalSubjectFilter: &v1.SubjectFilter{SubjectType: "user", OptionalSubjectId: "paul"},
+				})).To(BeEmpty())
 
 				// paul can only get his namespace
 				Expect(GetNamespace(ctx, paulClient, paulNamespace)).To(Succeed())

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -61,6 +61,14 @@ func WriteTuples(ctx context.Context, rels []*v1.Relationship) {
 	Expect(err).To(Succeed())
 }
 
+// DeleteAllTuples deletes every relationship matching the filter from SpiceDB.
+func DeleteAllTuples(ctx context.Context, filter *v1.RelationshipFilter) {
+	_, err := proxySrv.PermissionClient().DeleteRelationships(ctx, &v1.DeleteRelationshipsRequest{
+		RelationshipFilter: filter,
+	})
+	Expect(err).To(Succeed())
+}
+
 // setupEnvtest sets up the Kubernetes test binaries using setup-envtest
 func setupEnvtest(log logr.Logger) string {
 	e := &env.Env{

--- a/pkg/proxy/restmapper.go
+++ b/pkg/proxy/restmapper.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// synchronizedRESTMapper wraps a meta.RESTMapper to make it safe for concurrent use.
+//
+// The discovery-backed mapper this wraps (a shortcut expander over a disk-cached
+// discovery client) is not safe for concurrent use. On every call the shortcut
+// expander calls the discovery client's ServerGroupsAndResources() directly,
+// bypassing the DeferredDiscoveryRESTMapper's lock. When the on-disk discovery cache
+// is stale, that path rewrites the cache, and the versioning codec does a
+// read-modify-write on the cached object's TypeMeta (SetGroupVersionKind, then a
+// deferred restore). Two concurrent calls race on that field, tearing the APIVersion
+// string and panicking with a nil-pointer dereference in schema.ParseGroupVersion.
+//
+// The proxy shares a single mapper across all request goroutines and calls KindFor
+// while filtering every list/get response, so all access is serialized here.
+type synchronizedRESTMapper struct {
+	mu       sync.Mutex
+	delegate meta.RESTMapper
+}
+
+func newSynchronizedRESTMapper(delegate meta.RESTMapper) *synchronizedRESTMapper {
+	return &synchronizedRESTMapper{delegate: delegate}
+}
+
+var _ meta.RESTMapper = (*synchronizedRESTMapper)(nil)
+
+func (m *synchronizedRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.KindFor(resource)
+}
+
+func (m *synchronizedRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.KindsFor(resource)
+}
+
+func (m *synchronizedRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.ResourceFor(input)
+}
+
+func (m *synchronizedRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.ResourcesFor(input)
+}
+
+func (m *synchronizedRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.RESTMapping(gk, versions...)
+}
+
+func (m *synchronizedRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.RESTMappings(gk, versions...)
+}
+
+func (m *synchronizedRESTMapper) ResourceSingularizer(resource string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.delegate.ResourceSingularizer(resource)
+}

--- a/pkg/proxy/restmapper.go
+++ b/pkg/proxy/restmapper.go
@@ -2,72 +2,106 @@ package proxy
 
 import (
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// synchronizedRESTMapper wraps a meta.RESTMapper to make it safe for concurrent use.
+// cachingRESTMapper wraps a meta.RESTMapper to make it safe for concurrent use and to
+// memoize KindFor results.
 //
 // The discovery-backed mapper this wraps (a shortcut expander over a disk-cached
-// discovery client) is not safe for concurrent use. On every call the shortcut
+// discovery client) is not safe for concurrent use: on every call the shortcut
 // expander calls the discovery client's ServerGroupsAndResources() directly,
-// bypassing the DeferredDiscoveryRESTMapper's lock. When the on-disk discovery cache
-// is stale, that path rewrites the cache, and the versioning codec does a
-// read-modify-write on the cached object's TypeMeta (SetGroupVersionKind, then a
-// deferred restore). Two concurrent calls race on that field, tearing the APIVersion
-// string and panicking with a nil-pointer dereference in schema.ParseGroupVersion.
+// bypassing the DeferredDiscoveryRESTMapper's lock, and when the on-disk cache is
+// stale the versioning codec races on the cached object's TypeMeta during encoding.
+// All access is therefore serialized through a mutex.
 //
-// The proxy shares a single mapper across all request goroutines and calls KindFor
-// while filtering every list/get response, so all access is serialized here.
-type synchronizedRESTMapper struct {
-	mu       sync.Mutex
+// Serialization alone is correct but expensive: the shortcut expander re-reads and
+// JSON-decodes one discovery document per group-version on every KindFor call, which
+// is costly on CRD-heavy clusters and, under the lock, serializes that work across
+// all requests. Successful GVR->GVK lookups are memoized so the steady state is an
+// O(1) map read.
+//
+// Cached entries expire after ttl, which is set to the same TTL as the underlying
+// disk discovery cache. Memoization therefore never serves data staler than discovery
+// itself would, rather than caching indefinitely. Only successful lookups are cached;
+// errors (and not-yet-known resource types) are retried.
+type cachingRESTMapper struct {
 	delegate meta.RESTMapper
+	ttl      time.Duration
+	now      func() time.Time // overridable in tests
+
+	mu    sync.Mutex
+	cache map[schema.GroupVersionResource]kindForEntry
 }
 
-func newSynchronizedRESTMapper(delegate meta.RESTMapper) *synchronizedRESTMapper {
-	return &synchronizedRESTMapper{delegate: delegate}
+type kindForEntry struct {
+	gvk      schema.GroupVersionKind
+	storedAt time.Time
 }
 
-var _ meta.RESTMapper = (*synchronizedRESTMapper)(nil)
+func newCachingRESTMapper(delegate meta.RESTMapper, ttl time.Duration) *cachingRESTMapper {
+	return &cachingRESTMapper{
+		delegate: delegate,
+		ttl:      ttl,
+		now:      time.Now,
+		cache:    make(map[schema.GroupVersionResource]kindForEntry),
+	}
+}
 
-func (m *synchronizedRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+var _ meta.RESTMapper = (*cachingRESTMapper)(nil)
+
+func (m *cachingRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.delegate.KindFor(resource)
+
+	if e, ok := m.cache[resource]; ok && m.now().Sub(e.storedAt) < m.ttl {
+		return e.gvk, nil
+	}
+
+	gvk, err := m.delegate.KindFor(resource)
+	if err != nil {
+		// Don't cache failures: a transient discovery error or a not-yet-registered
+		// resource type must be retried, not memoized.
+		return gvk, err
+	}
+	m.cache[resource] = kindForEntry{gvk: gvk, storedAt: m.now()}
+	return gvk, nil
 }
 
-func (m *synchronizedRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+func (m *cachingRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.KindsFor(resource)
 }
 
-func (m *synchronizedRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+func (m *cachingRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.ResourceFor(input)
 }
 
-func (m *synchronizedRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+func (m *cachingRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.ResourcesFor(input)
 }
 
-func (m *synchronizedRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+func (m *cachingRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.RESTMapping(gk, versions...)
 }
 
-func (m *synchronizedRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+func (m *cachingRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.RESTMappings(gk, versions...)
 }
 
-func (m *synchronizedRESTMapper) ResourceSingularizer(resource string) (string, error) {
+func (m *cachingRESTMapper) ResourceSingularizer(resource string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.delegate.ResourceSingularizer(resource)

--- a/pkg/proxy/restmapper_test.go
+++ b/pkg/proxy/restmapper_test.go
@@ -2,17 +2,38 @@ package proxy
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 )
+
+// deploymentGVK is the kind deploymentsGVR resolves to.
+var deploymentGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+
+// countingRESTMapper is a test double that records how many times KindFor is invoked
+// and returns a configurable result. It embeds meta.RESTMapper (nil) to satisfy the
+// interface; only KindFor is exercised.
+type countingRESTMapper struct {
+	meta.RESTMapper
+	kindForCalls  int
+	kindForResult schema.GroupVersionKind
+	kindForErr    error
+}
+
+func (c *countingRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	c.kindForCalls++
+	return c.kindForResult, c.kindForErr
+}
 
 // deploymentsGVR is a stock Kubernetes resource used to exercise KindFor. The bug is
 // independent of which resource is resolved; any GVR served by discovery will do.
@@ -113,4 +134,69 @@ func TestNewCachedRESTMapper_ConcurrentKindForIsRaceFree(t *testing.T) {
 	for err := range errs {
 		require.NoError(t, err)
 	}
+}
+
+// TestCachingRESTMapper_MemoizesSuccessfulKindFor verifies repeated lookups for the
+// same resource resolve from the in-process cache rather than re-hitting the
+// (expensive, per-call discovery-reading) delegate on every request.
+func TestCachingRESTMapper_MemoizesSuccessfulKindFor(t *testing.T) {
+	underlying := &countingRESTMapper{kindForResult: deploymentGVK}
+	mapper := newCachingRESTMapper(underlying, time.Hour)
+
+	for i := 0; i < 5; i++ {
+		gvk, err := mapper.KindFor(deploymentsGVR)
+		require.NoError(t, err)
+		require.Equal(t, "Deployment", gvk.Kind)
+	}
+
+	require.Equal(t, 1, underlying.kindForCalls, "underlying KindFor should be invoked once and memoized thereafter")
+}
+
+// TestCachingRESTMapper_DoesNotCacheErrors verifies failed lookups are not cached, so a
+// transient discovery error (or a resource type that does not exist yet) is retried
+// rather than permanently poisoning the cache.
+func TestCachingRESTMapper_DoesNotCacheErrors(t *testing.T) {
+	underlying := &countingRESTMapper{kindForErr: errors.New("discovery unavailable")}
+	mapper := newCachingRESTMapper(underlying, time.Hour)
+
+	_, err := mapper.KindFor(deploymentsGVR)
+	require.Error(t, err)
+
+	// Discovery recovers; the next lookup must hit the underlying mapper again and succeed.
+	underlying.kindForErr = nil
+	underlying.kindForResult = deploymentGVK
+
+	gvk, err := mapper.KindFor(deploymentsGVR)
+	require.NoError(t, err)
+	require.Equal(t, "Deployment", gvk.Kind)
+	require.Equal(t, 2, underlying.kindForCalls, "error result must not be cached")
+}
+
+// TestCachingRESTMapper_RefreshesAfterTTL verifies the in-process cache honors the TTL:
+// a cached entry is re-resolved through the delegate once it is older than the TTL, so
+// memoization never serves data staler than the underlying discovery cache would.
+func TestCachingRESTMapper_RefreshesAfterTTL(t *testing.T) {
+	underlying := &countingRESTMapper{kindForResult: deploymentGVK}
+	mapper := newCachingRESTMapper(underlying, time.Hour)
+
+	now := time.Unix(1_000_000, 0)
+	mapper.now = func() time.Time { return now }
+
+	_, err := mapper.KindFor(deploymentsGVR) // miss -> delegate (calls=1)
+	require.NoError(t, err)
+	_, err = mapper.KindFor(deploymentsGVR) // hit (calls=1)
+	require.NoError(t, err)
+	require.Equal(t, 1, underlying.kindForCalls)
+
+	// Within the TTL: still served from cache.
+	now = now.Add(59 * time.Minute)
+	_, err = mapper.KindFor(deploymentsGVR)
+	require.NoError(t, err)
+	require.Equal(t, 1, underlying.kindForCalls, "entry within TTL should stay cached")
+
+	// Past the TTL: re-resolved through the delegate.
+	now = now.Add(2 * time.Minute) // total 61m > 60m TTL
+	_, err = mapper.KindFor(deploymentsGVR)
+	require.NoError(t, err)
+	require.Equal(t, 2, underlying.kindForCalls, "entry older than TTL should be refreshed")
 }

--- a/pkg/proxy/restmapper_test.go
+++ b/pkg/proxy/restmapper_test.go
@@ -1,0 +1,116 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+// deploymentsGVR is a stock Kubernetes resource used to exercise KindFor. The bug is
+// independent of which resource is resolved; any GVR served by discovery will do.
+var deploymentsGVR = schema.GroupVersionResource{
+	Group:    "apps",
+	Version:  "v1",
+	Resource: "deployments",
+}
+
+// newFakeDiscoveryServer serves a minimal Kubernetes discovery API (core/v1 plus the
+// apps group) so we can build a discovery-backed REST mapper in tests.
+func newFakeDiscoveryServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	writeJSON := func(w http.ResponseWriter, obj interface{}) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(obj)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, &metav1.APIVersions{
+			TypeMeta: metav1.TypeMeta{Kind: "APIVersions"},
+			Versions: []string{"v1"},
+		})
+	})
+	mux.HandleFunc("/api/v1", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, &metav1.APIResourceList{
+			TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Namespaced: true, Kind: "ConfigMap", ShortNames: []string{"cm"}},
+			},
+		})
+	})
+	mux.HandleFunc("/apis", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, &metav1.APIGroupList{
+			TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
+			Groups: []metav1.APIGroup{{
+				Name:             "apps",
+				Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: "apps/v1", Version: "v1"}},
+				PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "apps/v1", Version: "v1"},
+			}},
+		})
+	})
+	mux.HandleFunc("/apis/apps/v1", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, &metav1.APIResourceList{
+			TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Namespaced: true, Kind: "Deployment", ShortNames: []string{"deploy"}},
+			},
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, &metav1.APIResourceList{TypeMeta: metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"}})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestNewCachedRESTMapper_ConcurrentKindForIsRaceFree reproduces the production panic:
+// many concurrent requests are driven through a single shared REST mapper, and KindFor
+// on the discovery-backed mapper races on the discovery cache write (a read-modify-write
+// of the cached object's TypeMeta during encoding), corrupting a string and panicking
+// with a nil-pointer dereference inside ParseGroupVersion.
+//
+// A zero TTL forces the disk discovery cache to be rewritten on every call, which is the
+// path that races. Run under `-race` to detect it.
+func TestNewCachedRESTMapper_ConcurrentKindForIsRaceFree(t *testing.T) {
+	srv := newFakeDiscoveryServer(t)
+	cfg := &rest.Config{Host: srv.URL}
+
+	tmp := t.TempDir()
+	mapper, err := newCachedRESTMapper(cfg, filepath.Join(tmp, "discovery"), filepath.Join(tmp, "http"), 0)
+	require.NoError(t, err)
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			gvk, err := mapper.KindFor(deploymentsGVR)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if gvk.Kind != "Deployment" {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -233,11 +233,16 @@ func withAuthentication(handler, failed http.Handler, auth authenticator.Request
 // toRestMapper creates a rest.M from the provided rest.Config.
 func toRestMapper(config *rest.Config) (meta.RESTMapper, error) {
 	cacheDir := getDefaultCacheDir()
-
 	httpCacheDir := filepath.Join(cacheDir, "http")
 	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(cacheDir, "discovery"), config.Host)
+	return newCachedRESTMapper(config, discoveryCacheDir, httpCacheDir, 6*time.Hour)
+}
 
-	discoveryClient, err := diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, 6*time.Hour)
+// newCachedRESTMapper builds the discovery-backed REST mapper used to resolve
+// GroupVersionKinds while filtering responses. The cache directories and TTL are
+// parameters (rather than hardcoded) so the mapper can be exercised in tests.
+func newCachedRESTMapper(config *rest.Config, discoveryCacheDir, httpCacheDir string, ttl time.Duration) (meta.RESTMapper, error) {
+	discoveryClient, err := diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, ttl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discovery client: %w", err)
 	}
@@ -245,7 +250,7 @@ func toRestMapper(config *rest.Config) (meta.RESTMapper, error) {
 	expander := restmapper.NewShortcutExpander(mapper, discoveryClient, func(a string) {
 		klog.V(3).InfoSDepth(1, "discovery warning", "error", err)
 	})
-	return expander, nil
+	return newSynchronizedRESTMapper(expander), nil
 }
 
 // getDefaultCacheDir returns default caching directory path.

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -250,7 +250,10 @@ func newCachedRESTMapper(config *rest.Config, discoveryCacheDir, httpCacheDir st
 	expander := restmapper.NewShortcutExpander(mapper, discoveryClient, func(a string) {
 		klog.V(3).InfoSDepth(1, "discovery warning", "error", err)
 	})
-	return newSynchronizedRESTMapper(expander), nil
+	// Wrap with a caching mapper that serializes access (the discovery-backed mapper
+	// is not concurrency-safe) and memoizes KindFor results using the same TTL as the
+	// discovery cache, so per-request discovery reads don't dominate under load.
+	return newCachingRESTMapper(expander, ttl), nil
 }
 
 // getDefaultCacheDir returns default caching directory path.

--- a/pkg/spicedb/spicedb.go
+++ b/pkg/spicedb/spicedb.go
@@ -45,6 +45,18 @@ func NewServer(ctx context.Context, bootstrapFilePath string, bootstrapContent m
 		server.WithDispatchCacheConfig(server.CacheConfig{Enabled: false, Metrics: false}),
 		server.WithNamespaceCacheConfig(server.CacheConfig{Enabled: false, Metrics: false}),
 		server.WithClusterDispatchCacheConfig(server.CacheConfig{Enabled: false, Metrics: false}),
+		// Disable metrics on the stored-schema cache. With Metrics: true (the default) the
+		// cache registers Prometheus collectors named "stored_schema" on the global
+		// registry, so creating more than one embedded instance in a single process (as the
+		// tests do) fails with "duplicate metrics collector registration attempted". With
+		// Metrics: false the cache is built without registering anything.
+		server.WithStoredSchemaCacheConfig(server.CacheConfig{
+			Name:        "stored_schema",
+			Enabled:     true,
+			Metrics:     false,
+			NumCounters: 1_000,
+			MaxCost:     "32MiB",
+		}),
 		server.WithEnableRelationshipExpiration(true),
 		server.WithDatastoreConfig(
 			*datastore.NewConfigWithOptionsAndDefaults().WithOptions(


### PR DESCRIPTION
## Summary

Fixes pre-existing flakiness in the e2e "two users" namespace-watch specs by cleaning up per-spec state at its source, and adds a regression guard for the dual-write rollback path.

**Depends on #199** — ⚠️ do not merge before #199. The e2e suite only runs once #199's embedded-SpiceDB metrics fix is present, so this PR currently carries #199's commits in its diff; once #199 merges to `main`, this collapses to just the e2e change. (It targets `main` rather than #199's branch because the repo's Build & Test workflow only runs for PRs whose base is `main`.) This is **unrelated** to #199's REST-mapper race — it's pre-existing e2e test-harness debt that #199 merely *unmasked* by letting the suite run far enough to reach these specs.

## Root cause

`paul` and `chani` are the *same* identities across all specs, and each spec's namespace `creator`/`viewer` relationships are **never cleaned up** (envtest has no namespace GC, and `AfterEach` only orphan-deletes the namespaces). So each user's set of viewable namespaces grows every spec. The cluster-scoped `WatchNamespaces` helper returns the *first* event, so once stale namespaces have accumulated it returns one of them instead of the namespace the spec just created. (Only the namespace watch is affected — `WatchPods` is scoped to a fresh per-spec namespace.)

## Fix (at the source)

- **`AfterEach` deletes the namespace relationships the spec created**, so grants don't accumulate across specs (new `DeleteAllTuples` helper). The specs run **sequentially** (ginkgo, no `-p`/`--procs`), so this can't race another spec.
- With no stale state, each user sees **exactly** their own namespace, so the list assertion is tightened to an exact `ConsistOf` — a robust leak check that fails on **any** cross-user namespace, current or stale. (An earlier attempt filtered the *watch* to the expected name, but that could hide a leaked stale namespace; cleanup + the list snapshot avoids that.)

## Rollback guard (investigation result)

A hypothesis from the CI logs was that `recovers when there are kube write failures` leaves a dangling `creator` grant after paul's failed create of chani's namespace (which would let paul see it). I added an explicit assertion for that invariant. **It passes in both lock modes** — the dual-write rollback is correct — so it stands as a regression guard, not a bug fix.

## Testing

Affected specs pass locally (focused, k8s 1.33 envtest). The flake itself only reproduces under CI accumulation/ordering, so CI is the confirmation.
