### PR TITLE
Check for docker and kustomizer before dev:up

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ mage test:all
 
 ## Development environment
 
+The development environment requires [Docker](https://docs.docker.com/get-docker/) and
+[kustomizer](https://github.com/stefanprodan/kustomizer) to be installed:
+
+```bash
+brew install --cask docker
+brew install stefanprodan/tap/kustomizer
+```
+
 ```bash
 mage dev:up
 ```


### PR DESCRIPTION
Fixes #177.

`mage dev:up` previously failed deep inside kind with a stack trace when docker or kustomizer was missing, giving no hint about the actual prerequisite. This checks for both up front so it fails fast with a clear install message, and documents the requirement in the README.

- `dev.go`: call `checkDocker()`/`checkKustomizer()` at the start of `Dev.Up` (helpers already exist in `util.go`).
- `README.md`: document Docker + kustomizer as dev prerequisites.

BEFORE: `exec: "docker": executable file not found in $PATH` buried under a ~20-line kind stack trace.
AFTER: `docker must be installed to run kind - install with: brew install --cask docker`.